### PR TITLE
Update Boost and ICU

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -21,10 +21,12 @@ jobs:
       
     steps:
       - name: Perform checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         
       - name: Install Python environment 
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
         
       - name: Install conan
         run: |

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-22.04, macos-latest]
         build_type: [Debug, Release]
 
     runs-on: ${{ matrix.os }}
@@ -26,15 +26,18 @@ jobs:
       - name: Install Python environment 
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
         
       - name: Install conan
         run: |
             pip install conan --upgrade
+
+      - name: Create default profile
+        run: |
             conan profile detect --force
                     
       - name: Linux build
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
             conan create . -o openE57/*:with_tools=True -s build_type=${{ matrix.build_type }} -s compiler.cppstd=17 --build=missing
             

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -34,10 +34,10 @@ jobs:
       - name: Linux build
         if: matrix.os == 'ubuntu-20.04'
         run: |
-            conan create . -o openE57/*:with_tools=True -s build_type=${{ matrix.build_type }} --build=missing
+            conan create . -o openE57/*:with_tools=True -s build_type=${{ matrix.build_type }} -s compiler.cppstd=17 --build=missing
             
       - name: Mac build
         if: matrix.os == 'macos-latest'
         run: |
-            conan create . -s build_type=${{ matrix.build_type }} --build=missing
+            conan create . -s build_type=${{ matrix.build_type }} -s compiler.cppstd=17 --build=missing
             

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -29,17 +29,15 @@ jobs:
       - name: Install conan
         run: |
             pip install conan --upgrade
-            conan profile detect --force
-            conan profile update settings.build_type=${{ matrix.build_type }} default
+            conan profile new default --detect
                     
       - name: Linux build
         if: matrix.os == 'ubuntu-20.04'
         run: |
-            conan profile update settings.compiler.libcxx=libstdc++11 default
-            conan create . -o openE57:with_tools=True --build=missing
+            conan create . -o openE57:with_tools=True -s build_type=${{ matrix.build_type }} --build=missing
             
       - name: Mac build
         if: matrix.os == 'macos-latest'
         run: |
-            conan create . --build=missing
+            conan create . -s build_type=${{ matrix.build_type }} --build=missing
             

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -1,4 +1,4 @@
-name: openE57
+name: openE57-unix
 
 on:
   push:

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install conan
         run: |
             pip install conan --upgrade
-            conan profile new default --detect
+            conan profile detect --force
                     
       - name: Linux build
         if: matrix.os == 'ubuntu-20.04'

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install conan
         run: |
             pip install conan --upgrade
-            conan profile new default --detect
+            conan profile detect --force
             conan profile update settings.build_type=${{ matrix.build_type }} default
                     
       - name: Linux build

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Linux build
         if: matrix.os == 'ubuntu-20.04'
         run: |
-            conan create . -o openE57:with_tools=True -s build_type=${{ matrix.build_type }} --build=missing
+            conan create . -o openE57/*:with_tools=True -s build_type=${{ matrix.build_type }} --build=missing
             
       - name: Mac build
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -48,7 +48,7 @@ jobs:
             
       - name: Configure conan profile
         run: |
-            conan profile new ${{ matrix.build_type }}-${{ matrix.runtime_type }} --detect
+            conan profile detect --force
             conan profile update settings.build_type=${{ matrix.build_type }} ${{ matrix.build_type }}-${{ matrix.runtime_type }}
             conan profile update settings.compiler.runtime=${{ matrix.runtime_type }} ${{ matrix.build_type }}-${{ matrix.runtime_type }}
                     

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -35,10 +35,12 @@ jobs:
       
     steps:
       - name: Perform checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         
       - name: Install Python environment 
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
         
       - name: Install conan
         run: |

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -11,20 +11,7 @@ jobs:
       matrix:
         os: [windows-latest]
         build_type: [Release, Debug]
-        runtime_type: [MT, MTd, MD, MDd]
-        exclude:
-          - os: windows-latest
-            build_type: Release
-            runtime_type: MTd
-          - os: windows-latest
-            build_type: Release
-            runtime_type: MDd
-          - os: windows-latest
-            build_type: Debug
-            runtime_type: MT
-          - os: windows-latest
-            build_type: Debug
-            runtime_type: MD
+        runtime_type: [static, dynamic]
 
     runs-on: ${{ matrix.os }}
     

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Windows Release build
         if: matrix.build_type == 'Release'
         run: |
-            conan create . -o openE57:with_tools=True --build=missing -s build_type=${{ matrix.build_type }} -s compiler.runtime=${{ matrix.runtime_type }}
+            conan create . -o openE57/*:with_tools=True --build=missing -s build_type=${{ matrix.build_type }} -s compiler.runtime=${{ matrix.runtime_type }}
       
       - name: Windows Debug build
         if: matrix.build_type == 'Debug'

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -1,4 +1,4 @@
-name: openE57
+name: openE57-windows
 
 on:
   push:

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -48,9 +48,9 @@ jobs:
       - name: Windows Release build
         if: matrix.build_type == 'Release'
         run: |
-            conan create . -o openE57/*:with_tools=True --build=missing -s build_type=${{ matrix.build_type }} -s compiler.runtime=${{ matrix.runtime_type }}
+            conan create . -o openE57/*:with_tools=True --build=missing -s build_type=${{ matrix.build_type }} -s compiler.cppstd=17 -s compiler.runtime=${{ matrix.runtime_type }}
       
       - name: Windows Debug build
         if: matrix.build_type == 'Debug'
         run: |
-            conan create . --build=missing -s build_type=${{ matrix.build_type }} -s compiler.runtime=${{ matrix.runtime_type }}
+            conan create . --build=missing -s build_type=${{ matrix.build_type }} -s compiler.cppstd=17 -s compiler.runtime=${{ matrix.runtime_type }}

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -43,21 +43,14 @@ jobs:
       - name: Install conan
         run: |
             pip install conan --upgrade
-            conan remote clean
-            conan remote add conancenter https://center.conan.io True --insert
-            
-      - name: Configure conan profile
-        run: |
             conan profile detect --force
-            conan profile update settings.build_type=${{ matrix.build_type }} ${{ matrix.build_type }}-${{ matrix.runtime_type }}
-            conan profile update settings.compiler.runtime=${{ matrix.runtime_type }} ${{ matrix.build_type }}-${{ matrix.runtime_type }}
-                    
+            
       - name: Windows Release build
         if: matrix.build_type == 'Release'
         run: |
-            conan create . -o openE57:with_tools=True --build=missing --profile ${{ matrix.build_type }}-${{ matrix.runtime_type }}
+            conan create . -o openE57:with_tools=True --build=missing -s build_type=${{ matrix.build_type }} -s compiler.runtime=${{ matrix.runtime_type }}
       
       - name: Windows Debug build
         if: matrix.build_type == 'Debug'
         run: |
-            conan create . --build=missing --profile ${{ matrix.build_type }}-${{ matrix.runtime_type }}
+            conan create . --build=missing -s build_type=${{ matrix.build_type }} -s compiler.runtime=${{ matrix.runtime_type }}

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -27,11 +27,14 @@ jobs:
       - name: Install Python environment 
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
         
       - name: Install conan
         run: |
             pip install conan --upgrade
+      
+      - name: Create default profile
+        run: |
             conan profile detect --force
             
       - name: Windows Release build

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ tmp/
 bin/*
 .devcontainer/
 .vscode/
+
+test_package/CMakeUserPresets.json

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ At the current state, Boost is still required when building the tools as in the 
 
 You need the following tools to build this library:
 
-* A C++17 compiler (MSVC 2017+, gcc 7+, clang 7+)
+* A C++17 compiler (MSVC 2017+, gcc 8+, clang 8+)
 * A recent version of CMake (3.15+)
 * A recent version of conan (2.0+)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You need the following tools to build this library:
 
 * A C++17 compiler (MSVC 2017+, gcc 7+, clang 7+)
 * A recent version of CMake (3.15+)
-* A recent version of conan (1.28+)
+* A recent version of conan (2.0+)
 
 ## Build Instructions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # openE57
 
-![openE57](https://github.com/madduci/openE57/workflows/openE57/badge.svg)
+[![openE57-windows](https://github.com/openE57/openE57/actions/workflows/build-win.yml/badge.svg?branch=master)](https://github.com/openE57/openE57/actions/workflows/build-win.yml)
+[![openE57-unix](https://github.com/openE57/openE57/actions/workflows/build-unix.yml/badge.svg?branch=master)](https://github.com/openE57/openE57/actions/workflows/build-unix.yml)
 
 openE57 is a forked version of the original LibE57 (http://www.libe57.org) project, with the intent to refine and optimize the source code in a modern C++ idiomatic way and remove unnecessary dependencies (e.g. Boost) in favour of the C++ Standard Library.
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -71,13 +71,13 @@ class Opene57Conan(ConanFile):
         
     def requirements(self):
         if self.options.with_tools:
-            self.requires("boost/1.80.0")
+            self.requires("boost/1.83.0")
 
         if self.options.with_docs:
             self.requires("doxygen/1.9.4")
 
         if self.settings.os == "Linux" or tools.is_apple_os(self.settings.os):
-            self.requires("icu/72.1")
+            self.requires("icu/74.1")
 
         self.requires("xerces-c/3.2.4")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -44,9 +44,9 @@ class Opene57Conan(ConanFile):
     @property
     def _minimum_compilers_version(self):
         return {
-            "Visual Studio": "15",
-            "gcc": "7",
-            "clang": "6",
+            "msvc": "15",
+            "gcc": "8",
+            "clang": "8",
             "apple-clang": "10",
         }
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -81,7 +81,7 @@ class Opene57Conan(ConanFile):
         if self.options.with_docs:
             self.requires("doxygen/1.9.4")
 
-        if self.settings.os == "Linux" or tools.is_apple_os(self.settings.os):
+        if self.settings.os != "Windows":
             self.requires("icu/74.1")
 
         self.requires("xerces-c/3.2.4")

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ import os
 
 class Opene57Conan(ConanFile):
     name = "opene57"
-    version = "1.6.3"
+    version = "1.6.5"
     description = "A C++ library for reading and writing E57 files, " \
                   "fork of the original libE57 (http://libe57.org)"
     topics = ("e57", "libe57", "3d", "astm")

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,14 @@
-from conans import ConanFile, tools, CMake
-from conan.tools.microsoft import msvc_runtime_flag
-from conans.errors import ConanInvalidConfiguration
 import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, export_conandata_patches, get, replace_in_file
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Version
+
+required_conan_version = ">=2.0.0"
 
 class Opene57Conan(ConanFile):
     name = "opene57"
@@ -25,8 +32,6 @@ class Opene57Conan(ConanFile):
                 "shared": False,
                 "fPIC": True
                }
-    generators = "cmake", "cmake_find_package"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -61,12 +66,12 @@ class Opene57Conan(ConanFile):
             raise ConanInvalidConfiguration("OpenE57 cannot be built as shared library yet")
             
         if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, 17)
+            check_min_cppstd(self, 17)
 
         minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)
         if not minimum_version:
             self.output.warn("C++17 support required. Your compiler is unknown. Assuming it supports C++17.")
-        elif tools.Version(self.settings.compiler.version) < minimum_version:
+        elif Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration("C++17 support required, which your compiler does not support.")
         
     def requirements(self):
@@ -81,32 +86,30 @@ class Opene57Conan(ConanFile):
 
         self.requires("xerces-c/3.2.4")
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["PROJECT_VERSION"] = self.version
-        self._cmake.definitions["BUILD_EXAMPLES"] = False
-        self._cmake.definitions["BUILD_TOOLS"] = self.options.with_tools
-        self._cmake.definitions["BUILD_TESTS"] = False
-        if self.settings.compiler == "Visual Studio":
-            self._cmake.definitions["BUILD_WITH_MT"] = "MT" in msvc_runtime_flag(self)
-        else:
-            self._cmake.definitions["CMAKE_POSITION_INDEPENDENT_CODE"] = self.options.get_safe("fPIC", True)
-        self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["PROJECT_VERSION"] = self.version
+        tc.variables["BUILD_EXAMPLES"] = False
+        tc.variables["BUILD_TOOLS"] = self.options.with_tools
+        tc.variables["BUILD_TESTS"] = False
+        if is_msvc(self):
+            tc.variables["BUILD_WITH_MT"] = is_msvc_static_runtime(self)
+        tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = self.options.shared
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="LICENSE.libE57", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, "LICENSE.libE57", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
         os.remove(os.path.join(self.package_folder, "CHANGELOG.md"))
-        tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*.dll")
 
     def package_info(self):
         if self.options.with_tools:

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,12 +1,8 @@
 cmake_minimum_required(VERSION 3.15.0 FATAL_ERROR)
 project(opene57_example CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
-find_package(opene57 REQUIRED)
+find_package(opene57 REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} example.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE opene57::opene57)
-target_include_directories(${PROJECT_NAME} PRIVATE ${opene57_INCLUDE_DIRS})
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,18 +1,26 @@
-import shutil,os
-from conan.tools.microsoft import msvc_runtime_flag
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
 
-class TestOpene57Conan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
-        if not tools.cross_building(self):
-            cmake = CMake(self)
-            cmake.configure()
-            cmake.build()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "opene57_example")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "opene57_example")
+            self.run(bin_path, env="conanrun")


### PR DESCRIPTION
Updated Boost and ICU versions, bumped the support to Conan 2.0.

The minimum supported compilers for conan are now:

* msvc 2017
* gcc 8
* clang 8