### PR TITLE
Build file updates

### DIFF
--- a/src/cmake/compiler_options.cmake
+++ b/src/cmake/compiler_options.cmake
@@ -38,8 +38,10 @@ else(MSVC)
       -Wall
       -Wextra
       -Wpedantic
-      $<$<CONFIG:RELEASE>:-O2>
-      $<$<CONFIG:DEBUG>:-O0 -g -p -pg>)
+      $<$<OR:$<CONFIG:RELEASE>,$<CONFIG:RELWITHDEBINFO>>:-O2>
+      $<$<CONFIG:DEBUG>:-O0 -g>
+      $<$<AND:$<CONFIG:DEBUG>,$<CXX_COMPILER_ID:GNU>>:-p -pg>
+  )
 
   list(APPEND compiler_definitions
     CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -23,9 +23,9 @@ generate_export_header(${PROJECT_NAME})
 set_target_properties(${PROJECT_NAME} PROPERTIES 
   DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX}
   MSVC_RUNTIME_LIBRARY "${CMAKE_MSVC_RUNTIME_LIBRARY}")
-target_compile_options(${PROJECT_NAME} PUBLIC ${compiler_options})
-target_compile_definitions(${PROJECT_NAME} PUBLIC ${compiler_definitions})
-target_link_options(${PROJECT_NAME} PUBLIC ${linker_flags})
+target_compile_options(${PROJECT_NAME} PRIVATE ${compiler_options})
+target_compile_definitions(${PROJECT_NAME} PRIVATE ${compiler_definitions})
+target_link_options(${PROJECT_NAME} PRIVATE ${linker_flags})
 
 target_include_directories(${PROJECT_NAME}
     PRIVATE 
@@ -47,9 +47,9 @@ add_library(${PROJECT_NAME}las ${LIBRARY_TYPE}
 set_target_properties(${PROJECT_NAME}las PROPERTIES 
   DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX}
   MSVC_RUNTIME_LIBRARY "${CMAKE_MSVC_RUNTIME_LIBRARY}")
-target_compile_options(${PROJECT_NAME}las PUBLIC ${compiler_options})
-target_compile_definitions(${PROJECT_NAME}las PUBLIC ${compiler_definitions})
-target_link_options(${PROJECT_NAME}las PUBLIC ${linker_flags})
+target_compile_options(${PROJECT_NAME}las PRIVATE ${compiler_options})
+target_compile_definitions(${PROJECT_NAME}las PRIVATE ${compiler_definitions})
+target_link_options(${PROJECT_NAME}las PRIVATE ${linker_flags})
 
 target_include_directories(${PROJECT_NAME}las
     PRIVATE 

--- a/src/lib/include/openE57/openE57.h
+++ b/src/lib/include/openE57/openE57.h
@@ -44,6 +44,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <cinttypes>
 
 #ifndef DOXYGEN // Doxygen is not handling namespaces well in @includelineno commands, so disable
 namespace e57


### PR DESCRIPTION
Hey, love what you did with openE57. So much simpler to integrate. :+1: 

I had some issues getting this lib to build and integrate into my app on some platforms, so I am sending you my patches to consider.

Issues I had, and why I changed the things:
On Arch Linux using Clang compiler, it didn't like the `using std::int___t`'s, so I added the cinttypes include explicitly.
On MacOS and iOS I had issues with the PUBLIC compiler and linker flags, mostly causing havoc with the Swift compiler in my mixed language project, also I wasn't too much of a fan of having my compiler and linker flags changed on the other platforms.
And Clang doesn't support the `-p` and `-pg` flags, so I changed them to be GCC only.