### PR TITLE
mingw-w64 fixes

### DIFF
--- a/src/cmake/compiler_options.cmake
+++ b/src/cmake/compiler_options.cmake
@@ -3,8 +3,8 @@ if(NOT DEFINED CMAKE_DEBUG_POSTFIX)
 endif()
 
 if(MSVC)
-  
-  list(APPEND compiler_options 
+
+  list(APPEND compiler_options
     /W4
     /permissive-
     $<$<CONFIG:RELEASE>:/O2 /Ob2 >
@@ -26,15 +26,40 @@ if(MSVC)
   list(APPEND linker_flags
     $<$<BOOL:${BUILD_SHARED_LIBS}>:/LTCG>
   )
-  
+
   if(BUILD_WITH_MT)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     message(STATUS "Selected MSVC_RUNTIME_LIBRARY: ${CMAKE_MSVC_RUNTIME_LIBRARY}")
   endif()
 
-else(MSVC)
+elseif(WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  # MinGW compiler on Windows
+  list(APPEND compiler_options
+      -Wall
+      -Wextra
+      -Wpedantic
+      $<$<OR:$<CONFIG:RELEASE>,$<CONFIG:RELWITHDEBINFO>>:-O2>
+      $<$<CONFIG:DEBUG>:-O0 -g>
+  )
 
-  list(APPEND compiler_options 
+  list(APPEND compiler_definitions
+    WIN32
+    WINDOWS
+    CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS
+    CRCPP_USE_CPP11
+    $<$<OR:$<CONFIG:RELEASE>,$<CONFIG:MINSIZEREL>>:_FORTIFY_SOURCE=2>
+  )
+
+  list(APPEND linker_flags
+    $<$<CONFIG:DEBUG>:-fno-omit-frame-pointer>
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:-static>
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:-static-libgcc>
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:-static-libstdc++>
+  )
+
+else() # MSVC
+
+  list(APPEND compiler_options
       -Wall
       -Wextra
       -Wpedantic
@@ -48,7 +73,7 @@ else(MSVC)
     CRCPP_USE_CPP11
     $<$<OR:$<CONFIG:RELEASE>,$<CONFIG:MINSIZEREL>>:_FORTIFY_SOURCE=2>
   )
- 
+
   list(APPEND linker_flags
     $<$<NOT:$<CXX_COMPILER_ID:AppleClang>>:-Wl,-z,defs>
     $<$<NOT:$<CXX_COMPILER_ID:AppleClang>>:-Wl,-z,now>

--- a/src/lib/include/openE57/openE57.h
+++ b/src/lib/include/openE57/openE57.h
@@ -39,12 +39,17 @@
 #  include <stdlib.h>
 #endif
 
+#include <cinttypes>
 #include <iostream>
 #include <limits> // standard integers definition and numeric limits
 #include <memory>
 #include <string>
 #include <vector>
-#include <cinttypes>
+
+#if defined(WIN32)
+#  include <sysinfoapi.h>
+#  include <timezoneapi.h>
+#endif
 
 #ifndef DOXYGEN // Doxygen is not handling namespaces well in @includelineno commands, so disable
 namespace e57

--- a/src/lib/include/openE57/openE57.h
+++ b/src/lib/include/openE57/openE57.h
@@ -46,7 +46,7 @@
 #include <string>
 #include <vector>
 
-#if defined(WIN32)
+#if defined(WIN32) && defined(__GNUC__)
 #  include <sysinfoapi.h>
 #  include <timezoneapi.h>
 #endif

--- a/src/lib/src/openE57Impl.cpp
+++ b/src/lib/src/openE57Impl.cpp
@@ -41,7 +41,7 @@
 #    include <unistd.h>
 
 #    include <fcntl.h>
-#    include <sys\stat.h>
+#    include <sys/stat.h>
 #  else
 #    error "no supported compiler defined"
 #  endif

--- a/src/lib/src/openE57Simple.cpp
+++ b/src/lib/src/openE57Simple.cpp
@@ -783,7 +783,7 @@ DEALINGS IN THE SOFTWARE.
 #    include <unistd.h>
 
 #    include <fcntl.h>
-#    include <sys\stat.h>
+#    include <sys/stat.h>
 #  else
 #    error "no supported compiler defined"
 #  endif

--- a/src/lib/src/openE57SimpleImpl.cpp
+++ b/src/lib/src/openE57SimpleImpl.cpp
@@ -48,8 +48,8 @@
 #    define __LARGE64_FILES
 #    include <cstring>
 #    include <fcntl.h>
+#    include <sys/stat.h>
 #    include <sys/types.h>
-#    include <sys\stat.h>
 #    include <unistd.h>
 #  else
 #    error "no supported compiler defined"

--- a/src/lib/src/time_conversion.cpp
+++ b/src/lib/src/time_conversion.cpp
@@ -92,6 +92,12 @@ constexpr const int    DAYS_IN_DEC                   = 31;
 [[nodiscard]] bool e57::utils::current_julian_date(double& julian_date //!< Number of days since noon Universal Time Jan 1, 4713 BCE (Julian calendar) [days]
                                                    ) noexcept
 {
+#if defined(WIN32) && defined(__GNUC__)
+  // Use time() for MinGW which doesn't support timespec_get
+  time_t current_time;
+  time(&current_time);
+  const double timebuffer_time_in_seconds = static_cast<double>(current_time);
+#else
   std::timespec time_spec;
 
   if (std::timespec_get(&time_spec, TIME_UTC) == 0)
@@ -101,6 +107,7 @@ constexpr const int    DAYS_IN_DEC                   = 31;
   };
 
   const double timebuffer_time_in_seconds = time_spec.tv_sec;
+#endif
 
   // timebuffer_time_in_seconds is the time in seconds since midnight (00:00:00), January 1, 1970,
   // coordinated universal time (UTC). Julian date for (00:00:00), January 1, 1970 is: 2440587.5 [days]


### PR DESCRIPTION
This is several fixes required to build opene57 using the mingw-w64 toolchain. I'm using mingw-w64 8.0.0 from Ubunutu 24.04

Here is the conan profile I'm using:
```
[settings]
os=Windows
arch=x86_64
compiler=gcc
compiler.version=10.3
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
build_type=Release

[buildenv]
CC=x86_64-w64-mingw32-gcc-posix
CXX=x86_64-w64-mingw32-g++-posix
AR=x86_64-w64-mingw32-ar
AS=x86_64-w64-mingw32-as
AR=x86_64-w64-mingw32-ld
RANLIB=x86_64-w64-mingw32-ranlib
STRIP=x86_64-w64-mingw32-strip
RC=x86_64-w64-mingw32-windres
```

Build process:
```
mkdir build && cd build
conan install --output-folder . --build=missing  -o with_tests=True -pr:h mingw ..
cd ..
cmake --preset conan-releeae
cmake --build --preset conan-release
```

Test run
```
wine ./build/src/lib/time_conversion_test.exe
006c:err:explorer:initialize_display_settings Failed to query current display settings for L"\\\\.\\DISPLAY1".
[doctest] doctest version is "2.4.9"
[doctest] run with "--help" for options
===============================================================================
[doctest] test cases: 15 | 15 passed | 0 failed | 0 skipped
[doctest] assertions: 64 | 64 passed | 0 failed |
[doctest] Status: SUCCESS!
```
