### PR TITLE
Cmake build system improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ cmake_policy(SET CMP0091 NEW)
 
 project(openE57 VERSION 1.7.0 LANGUAGES C CXX DESCRIPTION "openE57 is a library for handling E57 files")
 
+set(XERCES_C_DEFAULT_FETCH_TAG "v3.3.0" CACHE STRING "Tag that is used for fetching xerces-c library")
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Available CMake Options are:
 * BUILD_TOOLS - builds the binary tools to validate and dump E57 files
 * BUILD_TESTS - builds tests
 * BUILD_SHARED_LIBS - actually unsupported (missing exported symbols)
+* XERCES_C_DEFAULT_FETCH_TAG - tag that is used for fetching and building xerces-c library from sources (if it's not found on your system)
 * BUILD_WITH_MT - instructs CMake to set the correct [`CMAKE_MSVC_RUNTIME_LIBRARY`](https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html?highlight=cmake_msvc_runtime_library) flag for Visual Studio
 
 Building with Position indipendent code on Unix can be activated with the option [`CMAKE_POSITION_INDEPENDENT_CODE`](https://cmake.org/cmake/help/latest/variable/CMAKE_POSITION_INDEPENDENT_CODE.html?highlight=cmake_position_independent_code).

--- a/src/cmake/dependencies.cmake
+++ b/src/cmake/dependencies.cmake
@@ -1,22 +1,37 @@
+include(FetchContent)
 # Find the Xerces libraries
 set(Xerces_USE_STATIC_LIBS ON)
-find_package(XercesC 3.2 REQUIRED)
-set(XML_LIBRARIES ${XercesC_LIBRARIES})
-set(XML_INCLUDE_DIRS ${XercesC_INCLUDE_DIRS})
+find_package(XercesC 3.2 QUIET)
+if (XercesC_FOUND)
+  set(XML_LIBRARIES ${XercesC_LIBRARIES})
+  set(XML_INCLUDE_DIRS ${XercesC_INCLUDE_DIRS})
+  # Add ICU in Linux Systems
+  if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Apple")
+    find_package(ICU REQUIRED)
+    set(XML_LIBRARIES ${XML_LIBRARIES} ${ICU_LIBRARIES})
+    set(XML_INCLUDE_DIRS ${XML_INCLUDE_DIRS} ${ICU_INCLUDE_DIRS})
+  endif()
+else()
+  if (NOT TARGET xerces-c)
+    set(XERCES_C_REPO https://github.com/apache/xerces-c.git)
+    FetchContent_Declare(
+      xerces-c
+      EXCLUDE_FROM_ALL
+      GIT_REPOSITORY ${XERCES_C_REPO}
+      GIT_TAG v3.3.0
+      GIT_SHALLOW TRUE
+    )
+    FetchContent_MakeAvailable(xerces-c)
+  endif()
+  set(XML_LIBRARIES "xerces-c")
+  get_target_property(XercesC_INCLUDE_DIRS xerces-c INCLUDE_DIRECTORIES)
+  set(XML_INCLUDE_DIRS ${XercesC_INCLUDE_DIRS})
+endif()
+
 if(NOT BUILD_SHARED_LIBS)
   list(APPEND compiler_definitions XERCES_STATIC_LIBRARY)
 endif()
   
-# Add ICU in Linux Systems
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Apple")
-  list(APPEND compiler_definitions LINUX)
-  find_package(ICU REQUIRED)
-  set(XML_LIBRARIES ${XML_LIBRARIES} ${ICU_LIBRARIES})
-  set(XML_INCLUDE_DIRS ${XML_INCLUDE_DIRS} ${ICU_INCLUDE_DIRS})
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
-  list(APPEND compiler_definitions WINDOWS)
-endif()
-
 # Find Boost (Required by Tools)
 if(BUILD_TOOLS)
   if(NOT BUILD_SHARED_LIBS) 

--- a/src/cmake/dependencies.cmake
+++ b/src/cmake/dependencies.cmake
@@ -18,7 +18,7 @@ else()
       xerces-c
       EXCLUDE_FROM_ALL
       GIT_REPOSITORY ${XERCES_C_REPO}
-      GIT_TAG v3.3.0
+      GIT_TAG ${XERCES_C_DEFAULT_FETCH_TAG}
       GIT_SHALLOW TRUE
     )
     FetchContent_MakeAvailable(xerces-c)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -28,9 +28,14 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE ${compiler_definitions})
 target_link_options(${PROJECT_NAME} PRIVATE ${linker_flags})
 
 target_include_directories(${PROJECT_NAME}
-    PRIVATE 
+    PUBLIC 
       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
       ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_include_directories(${PROJECT_NAME}
+    PRIVATE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
       ${XML_INCLUDE_DIRS} 
 )
 
@@ -52,9 +57,14 @@ target_compile_definitions(${PROJECT_NAME}las PRIVATE ${compiler_definitions})
 target_link_options(${PROJECT_NAME}las PRIVATE ${linker_flags})
 
 target_include_directories(${PROJECT_NAME}las
-    PRIVATE 
+    PUBLIC 
       $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
       ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_include_directories(${PROJECT_NAME}las
+    PRIVATE
+      $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
       ${XML_INCLUDE_DIRS}
 )
 


### PR DESCRIPTION
Greetings. I'd like to suggest a few cmake changes:

1) building xerces-c library from sources if it's not found by find_package (e.g. if I don't use any package manager);
2) expose library headers, so that when I use `target_link_libraries(MyTarget openE57)` it will automatically grab it's includes.