### PR TITLE
Some small changes to modernize the codebase, fix some typos and compiler warnings

### DIFF
--- a/src/lib/include/openE57/impl/openE57Impl.h
+++ b/src/lib/include/openE57/impl/openE57Impl.h
@@ -401,7 +401,7 @@ public:
   void         checkBuffers(const std::vector<SourceDestBuffer>& sdbufs, bool allowMissing);
   bool         findTerminalPosition(std::shared_ptr<NodeImpl> ni, uint64_t& countFromLeft);
 
-  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = NULL) = 0;
+  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = nullptr) = 0;
 
   virtual ~NodeImpl(){};
 
@@ -454,7 +454,7 @@ public:
 
   virtual void checkLeavesInSet(const std::set<ustring>& pathNames, std::shared_ptr<NodeImpl> origin);
 
-  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = NULL);
+  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = nullptr);
 
 #ifdef E57_DEBUG
   void dump(int indent = 0, std::ostream& os = std::cout);
@@ -486,7 +486,7 @@ public:
   //???virtual void   set(const ustring& pathName, std::shared_ptr<NodeImpl> ni);
   //???virtual void   append(std::shared_ptr<NodeImpl> ni);
 
-  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = NULL);
+  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = nullptr);
 
 #ifdef E57_DEBUG
   void dump(int indent = 0, std::ostream& os = std::cout);
@@ -632,7 +632,7 @@ public:
 
   virtual void checkLeavesInSet(const std::set<ustring>& pathNames, std::shared_ptr<NodeImpl> origin);
 
-  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = NULL);
+  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = nullptr);
 
   /// Iterator constructors
   std::shared_ptr<CompressedVectorWriterImpl> writer(std::vector<SourceDestBuffer> sbufs);
@@ -688,7 +688,7 @@ public:
 
   virtual void checkLeavesInSet(const std::set<ustring>& pathNames, std::shared_ptr<NodeImpl> origin);
 
-  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = NULL);
+  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = nullptr);
 
 #ifdef E57_DEBUG
   void dump(int indent = 0, std::ostream& os = std::cout);
@@ -729,7 +729,7 @@ public:
 
   virtual void checkLeavesInSet(const std::set<ustring>& pathNames, std::shared_ptr<NodeImpl> origin);
 
-  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = NULL);
+  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = nullptr);
 
 #ifdef E57_DEBUG
   void dump(int indent = 0, std::ostream& os = std::cout);
@@ -764,7 +764,7 @@ public:
 
   virtual void checkLeavesInSet(const std::set<ustring>& pathNames, std::shared_ptr<NodeImpl> origin);
 
-  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = NULL);
+  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = nullptr);
 
 #ifdef E57_DEBUG
   void dump(int indent = 0, std::ostream& os = std::cout);
@@ -794,7 +794,7 @@ public:
 
   virtual void checkLeavesInSet(const std::set<ustring>& pathNames, std::shared_ptr<NodeImpl> origin);
 
-  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = NULL);
+  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = nullptr);
 
 #ifdef E57_DEBUG
   void dump(int indent = 0, std::ostream& os = std::cout);
@@ -824,7 +824,7 @@ public:
 
   virtual void checkLeavesInSet(const std::set<ustring>& pathNames, std::shared_ptr<NodeImpl> origin);
 
-  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = NULL);
+  virtual void writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& cf, int indent, const char* forcedFieldName = nullptr);
 
 #ifdef E57_DEBUG
   void dump(int indent = 0, std::ostream& os = std::cout);

--- a/src/lib/include/openE57/impl/openE57SimpleImpl.h
+++ b/src/lib/include/openE57/impl/openE57SimpleImpl.h
@@ -120,7 +120,7 @@ public:
   //
   //! This function returns the file header information
   virtual bool GetE57Root(E57Root& fileHeader //!< This is the main header information
-  );                                          //!< /return Returns true if sucessful
+  );                                          //!< /return Returns true if successful
 
   ////////////////////////////////////////////////////////////////////
   //
@@ -132,7 +132,7 @@ public:
   //! This function returns the Image2Ds header and positions the cursor
   virtual bool ReadImage2D(int32_t  imageIndex,   //!< This in the index into the Image2Ds vector
                            Image2D& Image2DHeader //!< pointer to the Image2D structure to receive the picture information
-  );                                              //!< /return Returns true if sucessful
+  );                                              //!< /return Returns true if successful
 
   //! This function returns the size of the image data
   virtual bool GetImage2DSizes(int32_t                 imageIndex,      //!< This in the index into the image2D vector
@@ -143,7 +143,7 @@ public:
                                int64_t&                imageSize,       //!< This is the total number of bytes for the image blob.
                                e57::Image2DType&       imageMaskType,   //!< This is E57_PNG_IMAGE_MASK if "imageMask" is defined in the projection
                                e57::Image2DType&       imageVisualType  //!< This is image type of the VisualReferenceRepresentation if given.
-  );                                                                    //!< /return Returns true if sucessful
+  );                                                                    //!< /return Returns true if successful
 
   //! This function reads the block
   virtual int64_t ReadImage2DData(int32_t                imageIndex,      //!< picture block index
@@ -161,7 +161,7 @@ public:
                                    int64_t&           imageHeight,  //!< The image height (in pixels).
                                    int64_t&           imageSize,    //!< This is the total number of bytes for the image blob.
                                    e57::Image2DType&  imageMaskType //!< This is E57_PNG_IMAGE_MASK if "imageMask" is defined in the projection
-  );                                                                //!< /return Returns true if sucessful
+  );                                                                //!< /return Returns true if successful
 
   virtual int64_t ReadImage2DNode(e57::StructureNode image,     //!< 1 of 3 projects or the visual
                                   e57::Image2DType   imageType, //!< identifies the image format desired.
@@ -180,14 +180,14 @@ public:
   //! This function returns the Data3D header and positions the cursor
   virtual bool ReadData3D(int32_t dataIndex,   //!< This in the index into the images3D vector
                           Data3D& data3DHeader //!< pointer to the Data3D structure to receive the image information
-  );                                           //!< /return Returns true if sucessful
+  );                                           //!< /return Returns true if successful
 
   //! This function returns the size of the point data
   virtual bool GetData3DSizes(int32_t  dataIndex,   //!< This in the index into the images3D vector
                               int64_t& rowMax,      //!< This is the maximum row size
                               int64_t& columnMax,   //!< This is the maximum column size
                               int64_t& pointsSize,  //!< This is the total number of point records
-                              int64_t& groupsSize,  //!< This is the total number of group reocrds
+                              int64_t& groupsSize,  //!< This is the total number of group records
                               int64_t& countSize,   //!< This is the maximum point count per group
                               bool&    bColumnIndex //!< This indicates that the idElementName is "columnIndex"
   );
@@ -198,7 +198,7 @@ public:
                                     int64_t* idElementValue,  //!< index for this group
                                     int64_t* startPointIndex, //!< Starting index in to the "points" data vector for the groups
                                     int64_t* pointCount       //!< size of the groups given
-  );                                                          //!< \return Return true if sucessful, false otherwise
+  );                                                          //!< \return Return true if successful, false otherwise
 
   //! This function sets up the point data fields
   /* All the non-nullptr buffers in the call below have number of elements = pointCount.
@@ -366,7 +366,7 @@ public:
                                      int64_t* idElementValue,  //!< index for this group
                                      int64_t* startPointIndex, //!< Starting index in to the "points" data vector for the groups
                                      int64_t* pointCount       //!< size of the groups given
-  );                                                           //!< \return Return true if sucessful, false otherwise
+  );                                                           //!< \return Return true if successful, false otherwise
 
   //! This function returns the file raw E57Root Structure Node
   virtual StructureNode GetRawE57Root(void); //!< /return Returns the E57Root StructureNode

--- a/src/lib/include/openE57/impl/openE57SimpleImpl.h
+++ b/src/lib/include/openE57/impl/openE57SimpleImpl.h
@@ -201,44 +201,47 @@ public:
   );                                                          //!< \return Return true if sucessful, false otherwise
 
   //! This function sets up the point data fields
-  /* All the non-NULL buffers in the call below have number of elements = pointCount.
+  /* All the non-nullptr buffers in the call below have number of elements = pointCount.
   Call the CompressedVectorReader::read() until all data is read.
   */
 
   virtual CompressedVectorReader SetUpData3DPointsData(
-    int32_t dataIndex,                    //!< data block index given by the NewData3D
-    int64_t pointCount,                   //!< size of each element buffer.
-    double* cartesianX,                   //!< pointer to a buffer with the X coordinate (in meters) of the point in Cartesian coordinates
-    double* cartesianY,                   //!< pointer to a buffer with the Y coordinate (in meters) of the point in Cartesian coordinates
-    double* cartesianZ,                   //!< pointer to a buffer with the Z coordinate (in meters) of the point in Cartesian coordinates
-    int8_t* cartesianInvalidState = NULL, //!< Value = 0 if the point is considered valid, 1 otherwise
+    int32_t dataIndex,                       //!< data block index given by the NewData3D
+    int64_t pointCount,                      //!< size of each element buffer.
+    double* cartesianX,                      //!< pointer to a buffer with the X coordinate (in meters) of the point in Cartesian coordinates
+    double* cartesianY,                      //!< pointer to a buffer with the Y coordinate (in meters) of the point in Cartesian coordinates
+    double* cartesianZ,                      //!< pointer to a buffer with the Z coordinate (in meters) of the point in Cartesian coordinates
+    int8_t* cartesianInvalidState = nullptr, //!< Value = 0 if the point is considered valid, 1 otherwise
 
-    double* intensity          = NULL, //!< pointer to a buffer with the Point response intensity. Unit is unspecified
-    int8_t* isIntensityInvalid = NULL, //!< Value = 0 if the intensity is considered valid, 1 otherwise
+    double* intensity          = nullptr, //!< pointer to a buffer with the Point response intensity. Unit is unspecified
+    int8_t* isIntensityInvalid = nullptr, //!< Value = 0 if the intensity is considered valid, 1 otherwise
 
-    uint16_t* colorRed       = NULL, //!< pointer to a buffer with the Red color coefficient. Unit is unspecified
-    uint16_t* colorGreen     = NULL, //!< pointer to a buffer with the Green color coefficient. Unit is unspecified
-    uint16_t* colorBlue      = NULL, //!< pointer to a buffer with the Blue color coefficient. Unit is unspecified
-    int8_t*   isColorInvalid = NULL, //!< Value = 0 if the color is considered valid, 1 otherwise
+    uint16_t* colorRed       = nullptr, //!< pointer to a buffer with the Red color coefficient. Unit is unspecified
+    uint16_t* colorGreen     = nullptr, //!< pointer to a buffer with the Green color coefficient. Unit is unspecified
+    uint16_t* colorBlue      = nullptr, //!< pointer to a buffer with the Blue color coefficient. Unit is unspecified
+    int8_t*   isColorInvalid = nullptr, //!< Value = 0 if the color is considered valid, 1 otherwise
 
-    double* sphericalRange        = NULL, //!< pointer to a buffer with the range (in meters) of points in spherical coordinates. Shall be non-negative
-    double* sphericalAzimuth      = NULL, //!< pointer to a buffer with the Azimuth angle (in radians) of point in spherical coordinates
-    double* sphericalElevation    = NULL, //!< pointer to a buffer with the Elevation angle (in radians) of point in spherical coordinates
-    int8_t* sphericalInvalidState = NULL, //!< Value = 0 if the range is considered valid, 1 otherwise
+    double* sphericalRange        = nullptr, //!< pointer to a buffer with the range (in meters) of points in spherical coordinates. Shall be non-negative
+    double* sphericalAzimuth      = nullptr, //!< pointer to a buffer with the Azimuth angle (in radians) of point in spherical coordinates
+    double* sphericalElevation    = nullptr, //!< pointer to a buffer with the Elevation angle (in radians) of point in spherical coordinates
+    int8_t* sphericalInvalidState = nullptr, //!< Value = 0 if the range is considered valid, 1 otherwise
 
-    int32_t* rowIndex = NULL, //!< pointer to a buffer with the row number of point (zero based). This is useful for data that is stored in a regular grid.Shall
-                              //!< be in the interval (0, 2^63).
-    int32_t* columnIndex = NULL, //!< pointer to a buffer with the column number of point (zero based). This is useful for data that is stored in a regular
-                                 //!< grid. Shall be in the interval (0, 2^63).
-    int8_t* returnIndex = NULL,  //!< pointer to a buffer with the number of this return (zero based). That is, 0 is the first return, 1 is the second, and so
-                                 //!< on. Shall be in the interval (0, returnCount). Only for multi-return sensors.
-    int8_t* returnCount = NULL,  //!< pointer to a buffer with the total number of returns for the pulse that this corresponds to. Shall be in the interval (0,
-                                 //!< 2^63). Only for multi-return sensors.
+    int32_t* rowIndex = nullptr,    //!< pointer to a buffer with the row number of point (zero based). This is useful for data that is stored in a regular
+                                    //!< grid.Shall
+                                    //!< be in the interval (0, 2^63).
+    int32_t* columnIndex = nullptr, //!< pointer to a buffer with the column number of point (zero based). This is useful for data that is stored in a regular
+                                    //!< grid. Shall be in the interval (0, 2^63).
+    int8_t* returnIndex = nullptr, //!< pointer to a buffer with the number of this return (zero based). That is, 0 is the first return, 1 is the second, and so
+                                   //!< on. Shall be in the interval (0, returnCount). Only for multi-return sensors.
+    int8_t* returnCount = nullptr, //!< pointer to a buffer with the total number of returns for the pulse that this corresponds to. Shall be in the interval
+                                   //!< (0,
+                                   //!< 2^63). Only for multi-return sensors.
 
-    double* timeStamp = NULL, //!< pointer to a buffer with the time (in seconds) since the start time for the data, which is given by acquisitionStart in the
-                              //!< parent Data3D Structure. Shall be non-negative
-    int8_t* isTimeStampInvalid = NULL, //!< Value = 0 if the timeStamp is considered valid, 1 otherwise
-    bool (*pointDataExtension)(ImageFile imf, StructureNode proto, int protoIndex, std::vector<SourceDestBuffer>& destBuffers) = NULL
+    double* timeStamp = nullptr, //!< pointer to a buffer with the time (in seconds) since the start time for the data, which is given by acquisitionStart in
+                                 //!< the
+                                 //!< parent Data3D Structure. Shall be non-negative
+    int8_t* isTimeStampInvalid = nullptr, //!< Value = 0 if the timeStamp is considered valid, 1 otherwise
+    bool (*pointDataExtension)(ImageFile imf, StructureNode proto, int protoIndex, std::vector<SourceDestBuffer>& destBuffers) = nullptr
 
   );
 
@@ -320,39 +323,42 @@ public:
 
   //! This function writes out blocks of point data
   virtual CompressedVectorWriter SetUpData3DPointsData(
-    int32_t dataIndex,                    //!< data block index given by the NewData3D
-    int64_t pointCount,                   //!< size of each of the buffers given
-    double* cartesianX,                   //!< pointer to a buffer with the X coordinate (in meters) of the point in Cartesian coordinates
-    double* cartesianY,                   //!< pointer to a buffer with the Y coordinate (in meters) of the point in Cartesian coordinates
-    double* cartesianZ,                   //!< pointer to a buffer with the Z coordinate (in meters) of the point in Cartesian coordinates
-    int8_t* cartesianInvalidState = NULL, //!< Value = 0 if the point is considered valid, 1 otherwise
+    int32_t dataIndex,                       //!< data block index given by the NewData3D
+    int64_t pointCount,                      //!< size of each of the buffers given
+    double* cartesianX,                      //!< pointer to a buffer with the X coordinate (in meters) of the point in Cartesian coordinates
+    double* cartesianY,                      //!< pointer to a buffer with the Y coordinate (in meters) of the point in Cartesian coordinates
+    double* cartesianZ,                      //!< pointer to a buffer with the Z coordinate (in meters) of the point in Cartesian coordinates
+    int8_t* cartesianInvalidState = nullptr, //!< Value = 0 if the point is considered valid, 1 otherwise
 
-    double* intensity          = NULL, //!< pointer to a buffer with the Point response intensity. Unit is unspecified
-    int8_t* isIntensityInvalid = NULL, //!< Value = 0 if the intensity is considered valid, 1 otherwise
+    double* intensity          = nullptr, //!< pointer to a buffer with the Point response intensity. Unit is unspecified
+    int8_t* isIntensityInvalid = nullptr, //!< Value = 0 if the intensity is considered valid, 1 otherwise
 
-    uint16_t* colorRed       = NULL, //!< pointer to a buffer with the Red color coefficient. Unit is unspecified
-    uint16_t* colorGreen     = NULL, //!< pointer to a buffer with the Green color coefficient. Unit is unspecified
-    uint16_t* colorBlue      = NULL, //!< pointer to a buffer with the Blue color coefficient. Unit is unspecified
-    int8_t*   isColorInvalid = NULL, //!< Value = 0 if the color is considered valid, 1 otherwise
+    uint16_t* colorRed       = nullptr, //!< pointer to a buffer with the Red color coefficient. Unit is unspecified
+    uint16_t* colorGreen     = nullptr, //!< pointer to a buffer with the Green color coefficient. Unit is unspecified
+    uint16_t* colorBlue      = nullptr, //!< pointer to a buffer with the Blue color coefficient. Unit is unspecified
+    int8_t*   isColorInvalid = nullptr, //!< Value = 0 if the color is considered valid, 1 otherwise
 
-    double* sphericalRange        = NULL, //!< pointer to a buffer with the range (in meters) of points in spherical coordinates. Shall be non-negative
-    double* sphericalAzimuth      = NULL, //!< pointer to a buffer with the Azimuth angle (in radians) of point in spherical coordinates
-    double* sphericalElevation    = NULL, //!< pointer to a buffer with the Elevation angle (in radians) of point in spherical coordinates
-    int8_t* sphericalInvalidState = NULL, //!< Value = 0 if the range is considered valid, 1 otherwise
+    double* sphericalRange        = nullptr, //!< pointer to a buffer with the range (in meters) of points in spherical coordinates. Shall be non-negative
+    double* sphericalAzimuth      = nullptr, //!< pointer to a buffer with the Azimuth angle (in radians) of point in spherical coordinates
+    double* sphericalElevation    = nullptr, //!< pointer to a buffer with the Elevation angle (in radians) of point in spherical coordinates
+    int8_t* sphericalInvalidState = nullptr, //!< Value = 0 if the range is considered valid, 1 otherwise
 
-    int32_t* rowIndex = NULL, //!< pointer to a buffer with the row number of point (zero based). This is useful for data that is stored in a regular grid.Shall
-                              //!< be in the interval (0, 2^63).
-    int32_t* columnIndex = NULL, //!< pointer to a buffer with the column number of point (zero based). This is useful for data that is stored in a regular
-                                 //!< grid. Shall be in the interval (0, 2^63).
-    int8_t* returnIndex = NULL,  //!< pointer to a buffer with the number of this return (zero based). That is, 0 is the first return, 1 is the second, and so
-                                 //!< on. Shall be in the interval (0, returnCount). Only for multi-return sensors.
-    int8_t* returnCount = NULL,  //!< pointer to a buffer with the total number of returns for the pulse that this corresponds to. Shall be in the interval (0,
-                                 //!< 2^63). Only for multi-return sensors.
+    int32_t* rowIndex = nullptr,    //!< pointer to a buffer with the row number of point (zero based). This is useful for data that is stored in a regular
+                                    //!< grid.Shall
+                                    //!< be in the interval (0, 2^63).
+    int32_t* columnIndex = nullptr, //!< pointer to a buffer with the column number of point (zero based). This is useful for data that is stored in a regular
+                                    //!< grid. Shall be in the interval (0, 2^63).
+    int8_t* returnIndex = nullptr, //!< pointer to a buffer with the number of this return (zero based). That is, 0 is the first return, 1 is the second, and so
+                                   //!< on. Shall be in the interval (0, returnCount). Only for multi-return sensors.
+    int8_t* returnCount = nullptr, //!< pointer to a buffer with the total number of returns for the pulse that this corresponds to. Shall be in the interval
+                                   //!< (0,
+                                   //!< 2^63). Only for multi-return sensors.
 
-    double* timeStamp = NULL, //!< pointer to a buffer with the time (in seconds) since the start time for the data, which is given by acquisitionStart in the
-                              //!< parent Data3D Structure. Shall be non-negative
-    int8_t* isTimeStampInvalid = NULL, //!< Value = 0 if the timeStamp is considered valid, 1 otherwise
-    bool (*pointDataExtension)(ImageFile imf, StructureNode proto, std::vector<SourceDestBuffer>& sourceBuffers) = NULL);
+    double* timeStamp = nullptr, //!< pointer to a buffer with the time (in seconds) since the start time for the data, which is given by acquisitionStart in
+                                 //!< the
+                                 //!< parent Data3D Structure. Shall be non-negative
+    int8_t* isTimeStampInvalid = nullptr, //!< Value = 0 if the timeStamp is considered valid, 1 otherwise
+    bool (*pointDataExtension)(ImageFile imf, StructureNode proto, std::vector<SourceDestBuffer>& sourceBuffers) = nullptr);
 
   //! This funtion writes out the group data
   virtual bool WriteData3DGroupsData(int32_t  dataIndex,       //!< data block index given by the NewData3D

--- a/src/lib/include/openE57/impl/time_conversion.h
+++ b/src/lib/include/openE57/impl/time_conversion.h
@@ -248,7 +248,7 @@ namespace utils
 
   /**
    * @brief Determines the number of day in year given the year, month, and day
-   * @remarks Performed independant comparison with http://www.mbari.org/staff/coletti/doytable.html
+   * @remarks Performed independent comparison with http://www.mbari.org/staff/coletti/doytable.html
    *
    * @return true if successful, false otherwise
    */

--- a/src/lib/include/openE57/openE57.h
+++ b/src/lib/include/openE57/openE57.h
@@ -757,7 +757,7 @@ enum ErrorCode
 class E57Exception : public std::exception
 {
 public:
-  virtual void        report(const char* reportingFileName = NULL, int reportingLineNumber = 0, const char* reportingFunctionName = NULL,
+  virtual void        report(const char* reportingFileName = nullptr, int reportingLineNumber = 0, const char* reportingFunctionName = nullptr,
                              std::ostream& os = std::cout) const;
   virtual ErrorCode   errorCode() const;
   virtual ustring     context() const;
@@ -769,7 +769,7 @@ public:
   virtual int         sourceLineNumber() const;
 
   //! \cond documentNonPublic   The following isn't part of the API, and isn't documented.
-  E57Exception(ErrorCode ecode, const ustring context, const char* srcFileName = NULL, int srcLineNumber = 0, const char* srcFunctionName = NULL);
+  E57Exception(ErrorCode ecode, const ustring context, const char* srcFileName = nullptr, int srcLineNumber = 0, const char* srcFunctionName = nullptr);
   ~E57Exception() throw(){};
 
 private:          //=================

--- a/src/lib/include/openE57/openE57.h
+++ b/src/lib/include/openE57/openE57.h
@@ -56,7 +56,7 @@ namespace e57
 {
 #endif
 
-// Use std type names for signed/unsigned integers in various witdths
+// Use std type names for signed/unsigned integers in various widths
 using std::int16_t;
 using std::int32_t;
 using std::int64_t;

--- a/src/lib/include/openE57/openE57Simple.h
+++ b/src/lib/include/openE57/openE57Simple.h
@@ -439,7 +439,7 @@ public:
   ustring sensorFirmwareVersion; //!< The version number for the firmware installed in the sensor at the time of data collection.
 
   float
-    temperature; //!< The ambient temperature, measured at the sensor, at the time of data collection (in degrees Celsius). Shall be ? ?273.15� (absolute zero).
+        temperature; //!< The ambient temperature, measured at the sensor, at the time of data collection (in degrees Celsius). Shall be ? ?273.15� (absolute zero).
   float relativeHumidity;    //!< The percentage relative humidity, measured at the sensor, at the time of data collection. Shall be in the interval [0, 100].
   float atmosphericPressure; //!< The atmospheric pressure, measured at the sensor, at the time of data collection (in Pascals). Shall be positive.
 
@@ -452,7 +452,7 @@ public:
   e57::CartesianBounds
     cartesianBounds; //!< The bounding region (in cartesian coordinates) of all the points in this Data3D (in the local coordinate system of the points).
   e57::SphericalBounds
-    sphericalBounds; //!< The bounding region (in spherical coordinates) of all the points in this Data3D (in the local coordinate system of the points).
+                       sphericalBounds; //!< The bounding region (in spherical coordinates) of all the points in this Data3D (in the local coordinate system of the points).
   e57::IntensityLimits intensityLimits; //!< The limits for the value of signal intensity that the sensor is capable of producing.
   e57::ColorLimits     colorLimits;     //!< The limits for the value of red, green, and blue color that the sensor is capable of producing.
 
@@ -716,44 +716,46 @@ public:
   ) const;                                            //!< @return Return true if sucessful, false otherwise
 
   //! @brief This function sets up the point data fields
-  /*! @details All the non-NULL buffers in the call below have number of elements = pointCount.
+  /*! @details All the non-nullptr buffers in the call below have number of elements = pointCount.
   Call the CompressedVectorReader::read() until all data is read.
   */
   CompressedVectorReader SetUpData3DPointsData(
     int32_t dataIndex,  //!< data block index given by the NewData3D
     int64_t pointCount, //!< size of each element buffer.
 
-    double* cartesianX,                   //!< pointer to a buffer with the X coordinate (in meters) of the point in Cartesian coordinates
-    double* cartesianY,                   //!< pointer to a buffer with the Y coordinate (in meters) of the point in Cartesian coordinates
-    double* cartesianZ,                   //!< pointer to a buffer with the Z coordinate (in meters) of the point in Cartesian coordinates
-    int8_t* cartesianInvalidState = NULL, //!< Value = 0 if the point is considered valid, 1 otherwise
+    double* cartesianX,                      //!< pointer to a buffer with the X coordinate (in meters) of the point in Cartesian coordinates
+    double* cartesianY,                      //!< pointer to a buffer with the Y coordinate (in meters) of the point in Cartesian coordinates
+    double* cartesianZ,                      //!< pointer to a buffer with the Z coordinate (in meters) of the point in Cartesian coordinates
+    int8_t* cartesianInvalidState = nullptr, //!< Value = 0 if the point is considered valid, 1 otherwise
 
-    double* intensity          = NULL, //!< pointer to a buffer with the Point response intensity. Unit is unspecified
-    int8_t* isIntensityInvalid = NULL, //!< Value = 0 if the intensity is considered valid, 1 otherwise
+    double* intensity          = nullptr, //!< pointer to a buffer with the Point response intensity. Unit is unspecified
+    int8_t* isIntensityInvalid = nullptr, //!< Value = 0 if the intensity is considered valid, 1 otherwise
 
-    uint16_t* colorRed       = NULL, //!< pointer to a buffer with the Red color coefficient. Unit is unspecified
-    uint16_t* colorGreen     = NULL, //!< pointer to a buffer with the Green color coefficient. Unit is unspecified
-    uint16_t* colorBlue      = NULL, //!< pointer to a buffer with the Blue color coefficient. Unit is unspecified
-    int8_t*   isColorInvalid = NULL, //!< Value = 0 if the color is considered valid, 1 otherwise
+    uint16_t* colorRed       = nullptr, //!< pointer to a buffer with the Red color coefficient. Unit is unspecified
+    uint16_t* colorGreen     = nullptr, //!< pointer to a buffer with the Green color coefficient. Unit is unspecified
+    uint16_t* colorBlue      = nullptr, //!< pointer to a buffer with the Blue color coefficient. Unit is unspecified
+    int8_t*   isColorInvalid = nullptr, //!< Value = 0 if the color is considered valid, 1 otherwise
 
-    double* sphericalRange        = NULL, //!< pointer to a buffer with the range (in meters) of points in spherical coordinates. Shall be non-negative
-    double* sphericalAzimuth      = NULL, //!< pointer to a buffer with the Azimuth angle (in radians) of point in spherical coordinates
-    double* sphericalElevation    = NULL, //!< pointer to a buffer with the Elevation angle (in radians) of point in spherical coordinates
-    int8_t* sphericalInvalidState = NULL, //!< Value = 0 if the range is considered valid, 1 otherwise
+    double* sphericalRange        = nullptr, //!< pointer to a buffer with the range (in meters) of points in spherical coordinates. Shall be non-negative
+    double* sphericalAzimuth      = nullptr, //!< pointer to a buffer with the Azimuth angle (in radians) of point in spherical coordinates
+    double* sphericalElevation    = nullptr, //!< pointer to a buffer with the Elevation angle (in radians) of point in spherical coordinates
+    int8_t* sphericalInvalidState = nullptr, //!< Value = 0 if the range is considered valid, 1 otherwise
 
-    int32_t* rowIndex = NULL,    //!< pointer to a buffer with the row number of point (zero based). This is useful for data that is stored in a regular grid.
+    int32_t* rowIndex = nullptr, //!< pointer to a buffer with the row number of point (zero based). This is useful for data that is stored in a regular grid.
                                  //!< Shall be in the interval (0, 2^31).
-    int32_t* columnIndex = NULL, //!< pointer to a buffer with the column number of point (zero based). This is useful for data that is stored in a regular
-                                 //!< grid. Shall be in the interval (0, 2^31).
-    int8_t* returnIndex = NULL,  //!< pointer to a buffer with the number of this return (zero based). That is, 0 is the first return, 1 is the second, and so
-                                 //!< on. Shall be in the interval (0, returnCount). Only for multi-return sensors.
-    int8_t* returnCount = NULL,  //!< pointer to a buffer with the total number of returns for the pulse that this corresponds to. Shall be in the interval (0,
-                                 //!< 2^7). Only for multi-return sensors.
+    int32_t* columnIndex = nullptr, //!< pointer to a buffer with the column number of point (zero based). This is useful for data that is stored in a regular
+                                    //!< grid. Shall be in the interval (0, 2^31).
+    int8_t* returnIndex = nullptr, //!< pointer to a buffer with the number of this return (zero based). That is, 0 is the first return, 1 is the second, and so
+                                   //!< on. Shall be in the interval (0, returnCount). Only for multi-return sensors.
+    int8_t* returnCount = nullptr, //!< pointer to a buffer with the total number of returns for the pulse that this corresponds to. Shall be in the interval
+                                   //!< (0,
+                                   //!< 2^7). Only for multi-return sensors.
 
-    double* timeStamp = NULL, //!< pointer to a buffer with the time (in seconds) since the start time for the data, which is given by acquisitionStart in the
-                              //!< parent Data3D Structure. Shall be non-negative
-    int8_t* isTimeStampInvalid = NULL, //!< Value = 0 if the timeStamp is considered valid, 1 otherwise
-    bool (*pointDataExtension)(ImageFile imf, StructureNode proto, int protoIndex, std::vector<SourceDestBuffer>& destBuffers) = NULL
+    double* timeStamp = nullptr, //!< pointer to a buffer with the time (in seconds) since the start time for the data, which is given by acquisitionStart in
+                                 //!< the
+                                 //!< parent Data3D Structure. Shall be non-negative
+    int8_t* isTimeStampInvalid = nullptr, //!< Value = 0 if the timeStamp is considered valid, 1 otherwise
+    bool (*pointDataExtension)(ImageFile imf, StructureNode proto, int protoIndex, std::vector<SourceDestBuffer>& destBuffers) = nullptr
 
   ) const; //!< @return Return true if sucessful, false otherwise
 
@@ -822,44 +824,47 @@ public:
   //* @details The user needs to config a Data3D structure with all the scanning information before making this call. */
 
   int32_t NewData3D(Data3D& data3DHeader, //!< pointer to the Data3D structure to receive the image information
-                    bool (*pointExtension)(ImageFile imf, StructureNode proto) = NULL) const; //!< @return Returns the index of the new scan's data3D block.
+                    bool (*pointExtension)(ImageFile imf, StructureNode proto) = nullptr) const; //!< @return Returns the index of the new scan's data3D block.
 
   //! @brief This function writes out blocks of point data
   CompressedVectorWriter SetUpData3DPointsData(
-    int32_t dataIndex,                    //!< data block index given by the NewData3D
-    int64_t pointCount,                   //!< size of each of the buffers given
-    double* cartesianX,                   //!< pointer to a buffer with the X coordinate (in meters) of the point in Cartesian coordinates
-    double* cartesianY,                   //!< pointer to a buffer with the Y coordinate (in meters) of the point in Cartesian coordinates
-    double* cartesianZ,                   //!< pointer to a buffer with the Z coordinate (in meters) of the point in Cartesian coordinates
-    int8_t* cartesianInvalidState = NULL, //!< Value = 0 if the point is considered valid, 1 otherwise
+    int32_t dataIndex,                       //!< data block index given by the NewData3D
+    int64_t pointCount,                      //!< size of each of the buffers given
+    double* cartesianX,                      //!< pointer to a buffer with the X coordinate (in meters) of the point in Cartesian coordinates
+    double* cartesianY,                      //!< pointer to a buffer with the Y coordinate (in meters) of the point in Cartesian coordinates
+    double* cartesianZ,                      //!< pointer to a buffer with the Z coordinate (in meters) of the point in Cartesian coordinates
+    int8_t* cartesianInvalidState = nullptr, //!< Value = 0 if the point is considered valid, 1 otherwise
 
-    double* intensity          = NULL, //!< pointer to a buffer with the Point response intensity. Unit is unspecified
-    int8_t* isIntensityInvalid = NULL, //!< Value = 0 if the intensity is considered valid, 1 otherwise
+    double* intensity          = nullptr, //!< pointer to a buffer with the Point response intensity. Unit is unspecified
+    int8_t* isIntensityInvalid = nullptr, //!< Value = 0 if the intensity is considered valid, 1 otherwise
 
-    uint16_t* colorRed       = NULL, //!< pointer to a buffer with the Red color coefficient. Unit is unspecified
-    uint16_t* colorGreen     = NULL, //!< pointer to a buffer with the Green color coefficient. Unit is unspecified
-    uint16_t* colorBlue      = NULL, //!< pointer to a buffer with the Blue color coefficient. Unit is unspecified
-    int8_t*   isColorInvalid = NULL, //!< Value = 0 if the color is considered valid, 1 otherwise
+    uint16_t* colorRed       = nullptr, //!< pointer to a buffer with the Red color coefficient. Unit is unspecified
+    uint16_t* colorGreen     = nullptr, //!< pointer to a buffer with the Green color coefficient. Unit is unspecified
+    uint16_t* colorBlue      = nullptr, //!< pointer to a buffer with the Blue color coefficient. Unit is unspecified
+    int8_t*   isColorInvalid = nullptr, //!< Value = 0 if the color is considered valid, 1 otherwise
 
-    double* sphericalRange        = NULL, //!< pointer to a buffer with the range (in meters) of points in spherical coordinates. Shall be non-negative
-    double* sphericalAzimuth      = NULL, //!< pointer to a buffer with the Azimuth angle (in radians) of point in spherical coordinates
-    double* sphericalElevation    = NULL, //!< pointer to a buffer with the Elevation angle (in radians) of point in spherical coordinates
-    int8_t* sphericalInvalidState = NULL, //!< Value = 0 if the range is considered valid, 1 otherwise
+    double* sphericalRange        = nullptr, //!< pointer to a buffer with the range (in meters) of points in spherical coordinates. Shall be non-negative
+    double* sphericalAzimuth      = nullptr, //!< pointer to a buffer with the Azimuth angle (in radians) of point in spherical coordinates
+    double* sphericalElevation    = nullptr, //!< pointer to a buffer with the Elevation angle (in radians) of point in spherical coordinates
+    int8_t* sphericalInvalidState = nullptr, //!< Value = 0 if the range is considered valid, 1 otherwise
 
-    int32_t* rowIndex = NULL, //!< pointer to a buffer with the row number of point (zero based). This is useful for data that is stored in a regular grid.Shall
-                              //!< be in the interval (0, 2^31).
-    int32_t* columnIndex = NULL, //!< pointer to a buffer with the column number of point (zero based). This is useful for data that is stored in a regular
-                                 //!< grid. Shall be in the interval (0, 2^31).
-    int8_t* returnIndex = NULL,  //!< pointer to a buffer with the number of this return (zero based). That is, 0 is the first return, 1 is the second, and so
-                                 //!< on. Shall be in the interval (0, returnCount). Only for multi-return sensors.
-    int8_t* returnCount = NULL,  //!< pointer to a buffer with the total number of returns for the pulse that this corresponds to. Shall be in the interval (0,
-                                 //!< 2^7). Only for multi-return sensors.
+    int32_t* rowIndex = nullptr,    //!< pointer to a buffer with the row number of point (zero based). This is useful for data that is stored in a regular
+                                    //!< grid.Shall
+                                    //!< be in the interval (0, 2^31).
+    int32_t* columnIndex = nullptr, //!< pointer to a buffer with the column number of point (zero based). This is useful for data that is stored in a regular
+                                    //!< grid. Shall be in the interval (0, 2^31).
+    int8_t* returnIndex = nullptr, //!< pointer to a buffer with the number of this return (zero based). That is, 0 is the first return, 1 is the second, and so
+                                   //!< on. Shall be in the interval (0, returnCount). Only for multi-return sensors.
+    int8_t* returnCount = nullptr, //!< pointer to a buffer with the total number of returns for the pulse that this corresponds to. Shall be in the interval
+                                   //!< (0,
+                                   //!< 2^7). Only for multi-return sensors.
 
-    double* timeStamp = NULL, //!< pointer to a buffer with the time (in seconds) since the start time for the data, which is given by acquisitionStart in the
-                              //!< parent Data3D Structure. Shall be non-negative
-    int8_t* isTimeStampInvalid = NULL, //!< Value = 0 if the timeStamp is considered valid, 1 otherwise
+    double* timeStamp = nullptr, //!< pointer to a buffer with the time (in seconds) since the start time for the data, which is given by acquisitionStart in
+                                 //!< the
+                                 //!< parent Data3D Structure. Shall be non-negative
+    int8_t* isTimeStampInvalid = nullptr, //!< Value = 0 if the timeStamp is considered valid, 1 otherwise
     bool (*pointDataExtension)(ImageFile imf, StructureNode proto, std::vector<SourceDestBuffer>& sourceBuffers)
-    = NULL) const; //!< @return Return true if sucessful, false otherwise
+    = nullptr) const; //!< @return Return true if sucessful, false otherwise
 
   //! @brief This funtion writes out the group data
   bool WriteData3DGroupsData(int32_t  dataIndex,       //!< data block index given by the NewData3D

--- a/src/lib/include/openE57/openE57Simple.h
+++ b/src/lib/include/openE57/openE57Simple.h
@@ -125,7 +125,7 @@ public:
   double elevationMinimum; //!< The minimum extent of the bounding region from the horizontal plane
   double elevationMaximum; //!< The maximum extent of the bounding region from the horizontal plane
   double azimuthStart;     //!< The starting azimuth angle defining the extent of the bounding region around the z axis
-  double azimuthEnd;       //!< The ending azimuth angle defining the extent of the bounding region around the z axix
+  double azimuthEnd;       //!< The ending azimuth angle defining the extent of the bounding region around the z axis
 };
 
 ////////////////////////////////////////////////////////////////////
@@ -319,7 +319,7 @@ public:
                                   //!< -E57_DOUBLE_MAX. If using a ScaledIntegerNode then this needs to be a minimum range value.
   double pointRangeMaximum;       //!< Indicates that the PointRecord cartesian and range fields should be configured with this maximum value E57_FLOAT_MAX or
                                   //!< E57_DOUBLE_MAX. If using a ScaledIntegerNode then this needs to be a maximum range value.
-  double pointRangeScaledInteger; //!< Indicates that the PointRecord cartesain and range fields should be configured as a ScaledIntegerNode with this scale
+  double pointRangeScaledInteger; //!< Indicates that the PointRecord cartesian and range fields should be configured as a ScaledIntegerNode with this scale
                                   //!< setting. If 0. then use FloatNode.
 
   double angleMinimum; //!< Indicates that the PointRecord angle fields should be configured with this minimum value -E57_FLOAT_MAX or -E57_DOUBLE_MAX. If using
@@ -630,7 +630,7 @@ public:
   //
   //! @brief This function returns the file header information
   bool GetE57Root(E57Root& fileHeader //!< This is the main header information
-  ) const;                            //!< @return Returns true if sucessful
+  ) const;                            //!< @return Returns true if successful
 
   ////////////////////////////////////////////////////////////////////
   //
@@ -642,7 +642,7 @@ public:
   //! @brief This function returns the image2D header and positions the cursor
   bool ReadImage2D(int32_t  imageIndex,   //!< This in the index into the image2D vector
                    Image2D& image2DHeader //!< pointer to the Image2D structure to receive the picture information
-  ) const;                                //!< @return Returns true if sucessful
+  ) const;                                //!< @return Returns true if successful
 
   //! @brief This function returns the size of the image data
   /*! @details The e57::Image2DType identifies the format representation for the image data
@@ -674,7 +674,7 @@ public:
                        int64_t&                imageSize,       //!< This is the total number of bytes for the image blob.
                        e57::Image2DType&       imageMaskType,   //!< This is E57_PNG_IMAGE_MASK if "imageMask" is defined in the projection
                        e57::Image2DType&       imageVisualType  //!< This is image type of the VisualReferenceRepresentation if given.
-  ) const;                                                      //!< @return Returns true if sucessful
+  ) const;                                                      //!< @return Returns true if successful
 
   //! @brief This function reads the block
   int64_t ReadImage2DData(int32_t                imageIndex,      //!< picture block index
@@ -695,17 +695,17 @@ public:
   //! @brief This function returns the Data3D header and positions the cursor
   bool ReadData3D(int32_t dataIndex,   //!< This in the index into the images3D vector
                   Data3D& data3DHeader //!< pointer to the Data3D structure to receive the image information
-  ) const;                             //!< @return Returns true if sucessful
+  ) const;                             //!< @return Returns true if successful
 
   //! @brief This function returns the size of the point data
   bool GetData3DSizes(int32_t  dataIndex,   //!< This in the index into the images3D vector
                       int64_t& rowMax,      //!< This is the maximum row size
                       int64_t& columnMax,   //!< This is the maximum column size
                       int64_t& pointsSize,  //!< This is the total number of point records
-                      int64_t& groupsSize,  //!< This is the total number of group reocrds
+                      int64_t& groupsSize,  //!< This is the total number of group records
                       int64_t& countSize,   //!< This is the maximum point count per group
                       bool&    bColumnIndex //!< This indicates that the idElementName is "columnIndex"
-  ) const;                                  //!< @return Return true if sucessful, false otherwise
+  ) const;                                  //!< @return Return true if successful, false otherwise
 
   //! @brief This funtion writes out the group data.
   bool ReadData3DGroupsData(int32_t  dataIndex,       //!< data block index given by the NewData3D
@@ -713,7 +713,7 @@ public:
                             int64_t* idElementValue,  //!< index for this group
                             int64_t* startPointIndex, //!< Starting index in to the "points" data vector for the groups
                             int64_t* pointCount       //!< size of the groups given
-  ) const;                                            //!< @return Return true if sucessful, false otherwise
+  ) const;                                            //!< @return Return true if successful, false otherwise
 
   //! @brief This function sets up the point data fields
   /*! @details All the non-nullptr buffers in the call below have number of elements = pointCount.
@@ -757,7 +757,7 @@ public:
     int8_t* isTimeStampInvalid = nullptr, //!< Value = 0 if the timeStamp is considered valid, 1 otherwise
     bool (*pointDataExtension)(ImageFile imf, StructureNode proto, int protoIndex, std::vector<SourceDestBuffer>& destBuffers) = nullptr
 
-  ) const; //!< @return Return true if sucessful, false otherwise
+  ) const; //!< @return Return true if successful, false otherwise
 
   ////////////////////////////////////////////////////////////////////
   //
@@ -872,7 +872,7 @@ public:
                              int64_t* idElementValue,  //!< index for this group
                              int64_t* startPointIndex, //!< Starting index in to the "points" data vector for the groups
                              int64_t* pointCount       //!< size of the groups given
-  ) const;                                             //!< @return Return true if sucessful, false otherwise
+  ) const;                                             //!< @return Return true if successful, false otherwise
 
   ////////////////////////////////////////////////////////////////////
   //

--- a/src/lib/src/openE57.cpp
+++ b/src/lib/src/openE57.cpp
@@ -975,7 +975,7 @@ In a production version, the buffer would be much larger than 8 characters.
 The buffers are sent to the @c cout ostream on <b>source line 39</b>, with appropriate casts to keep the compiler happy.
 The XML is not parsed, just read in blocks.
 If the file is corrupted and has checksum errors, the raw XML utility functions will fail.
-There are no E57 Fountation API functions to read a corrupt E57 file (a .e57 file with checksum errors).
+There are no E57 Foundation API functions to read a corrupt E57 file (a .e57 file with checksum errors).
 
 The following console output is produced:
 @includelineno RawXML.out
@@ -1723,7 +1723,7 @@ Newly constructed nodes (before they are inserted into an ImageFile tree) start 
 It is possible to temporarily create small trees that are unattached to any ImageFile.
 In these temporary trees, the top-most node will be a root node.
 After the tree is attached to the ImageFile tree, the only root node will be the pre-created one of the ImageTree (the one returned by ImageFile::root).
-The concept of @em attachement is slightly larger than that of the parent-child relationship (see Node::isAttached and CompressedVectorNode::CompressedVectorNode for more details).
+The concept of @em attachment is slightly larger than that of the parent-child relationship (see Node::isAttached and CompressedVectorNode::CompressedVectorNode for more details).
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  true if this node is a root node.
@@ -1747,7 +1747,7 @@ Due to the set-once design of the API, a parent-child relationship cannot be mod
 A child node can be any of the 8 node types, but a parent node can only be one of the 3 container node types (E57_STRUCTURE, E57_VECTOR, and E57_COMPRESSED_VECTOR).
 Each parent-child link has a string name (the elementName) associated with it (See Node::elementName for more details).
 More than one tree can be formed at any given time.
-Typically small trees are temporarily constructed before attachement to an ImageFile so that they will be written to the disk.
+Typically small trees are temporarily constructed before attachment to an ImageFile so that they will be written to the disk.
 
 @b Warning: user algorithms that use this function to walk the tree must take care to handle the case where a node is its own parent (it is a root node).
 Use Node::isRoot to avoid infinite loops or infinite recursion.
@@ -1914,7 +1914,7 @@ See Node class discussion for discussion of the common functions that StructureN
 A class invariant is a list of statements about an object that are always true before and after any operation on the object.
 An invariant is useful for testing correct operation of an implementation.
 Statements in an invariant can involve only externally visible state, or can refer to internal implementation-specific state that is not visible to the API
-user. The following C++ code checks externally visible state for consistancy and throws an exception if the invariant is violated:
+user. The following C++ code checks externally visible state for consistency and throws an exception if the invariant is violated:
 @dontinclude E57Foundation.cpp
 @skip begin StructureNode::checkInvariant
 @skip checkInvariant(
@@ -3611,7 +3611,7 @@ See Node class discussion for discussion of the common functions that StructureN
 A class invariant is a list of statements about an object that are always true before and after any operation on the object.
 An invariant is useful for testing correct operation of an implementation.
 Statements in an invariant can involve only externally visible state, or can refer to internal implementation-specific state that is not visible to the API
-user. The following C++ code checks externally visible state for consistancy and throws an exception if the invariant is violated:
+user. The following C++ code checks externally visible state for consistency and throws an exception if the invariant is violated:
 @dontinclude E57Foundation.cpp
 @skip begin ScaledIntegerNode::checkInvariant
 @skip checkInvariant(
@@ -5005,7 +5005,7 @@ ImageFile::ImageFile(std::shared_ptr<ImageFileImpl> imfi) : impl_(imfi) {}
 @class E57Exception
 @brief   Object thrown by E57 Foundation API functions to communicate the conditions of an error.
 @details
-The E57Exception object communicates information about errors occuring in calls to the E57 Foundation API functions.
+The E57Exception object communicates information about errors occurring in calls to the E57 Foundation API functions.
 The error information is communicated from the location in the E57 Foundation Implementation where the error was detected to the @c catch statement in the code
 of the API user. The state of E57Exception object has one mandatory field, the errorCode, and several optional fields that can be set depending on the debug
 level of the E57 Foundation Implementation. There are three optional fields that encode the location in the source code of the E57 Foundation Implementation
@@ -5038,7 +5038,7 @@ Almost all of the API functions can throw the following two ErrorCodes: E57_ERRO
 In some E57 Foundation Implementations, the tree information may be stored on disk rather than in memory.
 If the disk file is closed, even the most basic information may not be available about nodes in the tree.
 So if the ImageFile is closed (by calling ImageFile::close), the API user must be ready for many of the API functions to throw
-E57Exception(E57_ERROR_IMAGEFILE_NOT_OPEN). Secondly, regarding the E57_ERROR_INTERNAL error, there is a lot of consistancy checking in the Reference
+E57Exception(E57_ERROR_IMAGEFILE_NOT_OPEN). Secondly, regarding the E57_ERROR_INTERNAL error, there is a lot of consistency checking in the Reference
 Implementation, and there may be much more added. Even if some API routines do not now throw E57_ERROR_INTERNAL, they could some time in the future, or in
 different implementations. So the right to throw E57_ERROR_INTERNAL is reserved for every API function (except those that by design can't throw E57Exceptions).
 

--- a/src/lib/src/openE57.cpp
+++ b/src/lib/src/openE57.cpp
@@ -4422,7 +4422,7 @@ Since @a buf is a byte buffer, byte ordering is irrelevant (it will come out in 
 There is no constraint on the ordering of reads.
 Any part of the Blob data can be read zero or more times.
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@pre     buf != NULL
+@pre     buf != nullptr
 @pre     0 <= @a start < byteCount()
 @pre     0 <= count
 @pre     (@a start + @a count) < byteCount()
@@ -4457,7 +4457,7 @@ The BlobNode is one of the two node types that must be attached to the root of a
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @pre     The associated destImageFile must have been opened in write mode (i.e. destImageFile().isWritable()).
 @pre     The BlobNode must be attached to an ImageFile (i.e. isAttached()).
-@pre     buf != NULL
+@pre     buf != nullptr
 @pre     0 <= @a start < byteCount()
 @pre     0 <= count
 @pre     (@a start + @a count) < byteCount()
@@ -5059,9 +5059,9 @@ E57Exception::E57Exception(ErrorCode ecode, const ustring context, const char* s
 
 /*================*/ /*!
 @brief   Print error information on a given output stream.
-@param   [in] reportingFileName     Name of file where catch statement caught the exception.  NULL if unknown.
+@param   [in] reportingFileName     Name of file where catch statement caught the exception.  nullptr if unknown.
 @param   [in] reportingLineNumber   Number of source code line where catch statement caught the exception.  0 if unknown.
-@param   [in] reportingFunctionName String name of function containing catch statement that caught the exception.  NULL if unknown.
+@param   [in] reportingFunctionName String name of function containing catch statement that caught the exception.  nullptr if unknown.
 @param   [in] os Output string to print a summary of exception information and location of catch statement.
 @details
 The amount of information printed to output stream may depend on whether the E57 Foundation Implementation was built with debugging enabled.
@@ -5076,12 +5076,12 @@ void E57Exception::report(const char* reportingFileName, int reportingLineNumber
   os << "  Debug info: " << std::endl;
   os << "    context: " << context_ << std::endl;
   os << "    sourceFunctionName: " << sourceFunctionName_ << std::endl;
-  if (reportingFunctionName != NULL)
+  if (reportingFunctionName != nullptr)
     os << "    reportingFunctionName: " << reportingFunctionName << std::endl;
 
   /*** Add a line in error message that a smart editor (gnu emacs) can interpret as a link to the source code: */
   os << sourceFileName_ << "(" << sourceLineNumber_ << ") : error C" << errorCode_ << ":  <--- occurred on" << std::endl;
-  if (reportingFileName != NULL)
+  if (reportingFileName != nullptr)
     os << reportingFileName << "(" << reportingLineNumber << ") : error C0:  <--- reported on" << std::endl;
 #endif
 }

--- a/src/lib/src/openE57Impl.cpp
+++ b/src/lib/src/openE57Impl.cpp
@@ -1195,7 +1195,7 @@ int64_t SourceDestBufferImpl::getNextInt64(double scale, double offset)
 
   /// Reverse scale (undo scaling) of a user's number to get raw value to put in file.
 
-  /// Encorporating the scale is optional (requested by user when constructing the sdbuf).
+  /// Incorporating the scale is optional (requested by user when constructing the sdbuf).
   /// If the user did not request scaling, then we get raw values from user's buffer.
   if (!doScaling_)
   {
@@ -1519,9 +1519,9 @@ void SourceDestBufferImpl::setNextInt64(int64_t value, double scale, double offs
 {
   /// don't checkImageFileOpen
 
-  /// Apply a scale and offset to numbers from file before puting in user's buffer.
+  /// Apply a scale and offset to numbers from file before putting in user's buffer.
 
-  /// Encorporating the scale is optional (requested by user when constructing the sdbuf).
+  /// Incorporating the scale is optional (requested by user when constructing the sdbuf).
   /// If the user did not request scaling, then we send raw values to user's buffer.
   if (!doScaling_)
   {
@@ -2709,7 +2709,7 @@ void StringNodeImpl::writeXml(std::shared_ptr<ImageFileImpl> /*imf*/, CheckedFil
     size_t currentPosition = 0;
     size_t len             = value_.length();
 
-    /// Loop, searching for occurences of "]]>", which will be split across two CDATA directives
+    /// Loop, searching for occurrences of "]]>", which will be split across two CDATA directives
     while (currentPosition < len)
     {
       size_t found = value_.find("]]>", currentPosition);
@@ -3083,7 +3083,7 @@ private:
     int64_t        length;                     // used in E57_BLOB
     bool           allowHeterogeneousChildren; // used in E57_VECTOR
     int64_t        recordCount;                // used in E57_COMPRESSED_VECTOR
-    ustring        childText;                  // used by all types, accumlates all child text between tags
+    ustring        childText;                  // used by all types, accumulates all child text between tags
 
     /// Holds node for Structure, Vector, and CompressedVector so can append child elements
     std::shared_ptr<NodeImpl> container_ni;
@@ -4100,7 +4100,7 @@ int ImageFileImpl::readerCount()
 
 ImageFileImpl::~ImageFileImpl()
 {
-  /// Try to cancel if not already closed, but don't allow any exceptions to propogate to caller (because in dtor).
+  /// Try to cancel if not already closed, but don't allow any exceptions to propagate to caller (because in dtor).
   /// If writing, this will unlink the file, so make sure call ImageFileImpl::close explicitly before dtor runs.
   try
   {
@@ -5390,7 +5390,7 @@ char* DataPacket::getBytestream(unsigned bytestreamNumber, unsigned& byteCount)
   uint16_t* bsbLength  = reinterpret_cast<uint16_t*>(&payload[0]);
   char*     streamBase = reinterpret_cast<char*>(&bsbLength[bytestreamCount]);
 
-  /// Sum size of preceeding stream buffers to get position
+  /// Sum size of preceding stream buffers to get position
   unsigned totalPreceeding = 0;
   for (unsigned i = 0; i < bytestreamNumber; i++)
     totalPreceeding += bsbLength[i];
@@ -7081,7 +7081,7 @@ uint64_t BitpackFloatEncoder::processRecords(size_t recordCount)
 #ifdef E57_MAX_VERBOSE
       cout << "encoding float: " << outp[i] << endl;
 #endif
-      SWAB(&outp[i]); /// swab if neccesary
+      SWAB(&outp[i]); /// swab if necessary
     }
   }
   else
@@ -7096,7 +7096,7 @@ uint64_t BitpackFloatEncoder::processRecords(size_t recordCount)
 #ifdef E57_MAX_VERBOSE
       cout << "encoding double: " << outp[i] << endl;
 #endif
-      SWAB(&outp[i]); /// swab if neccesary
+      SWAB(&outp[i]); /// swab if necessary
     }
   }
 
@@ -7357,7 +7357,7 @@ std::shared_ptr<Decoder> Decoder::DecoderFactory(unsigned                       
     unsigned bitsPerRecord = imf->bitsNeeded(sini->minimum(), sini->maximum());
 
     //!!! need to pick smarter channel buffer sizes, here and elsewhere
-    /// Constuct ScaledInteger dencoder with appropriate register size, based on number of bits stored.
+    /// Construct ScaledInteger decoder with appropriate register size, based on number of bits stored.
     if (bitsPerRecord == 0)
     {
       std::shared_ptr<Decoder> decoder(
@@ -7468,7 +7468,7 @@ size_t BitpackDecoder::inputProcess(const char* source, const size_t availableBy
     /// ??? fix doc for new bit interface
     /// Now that we have input stored in an aligned buffer, call derived class to try to eat some
     /// Note that end of filled buffer may not be at a natural boundary.
-    /// The subclass may transfer this partial word in a full word transfer, but it must be carefull to only use the defined bits.
+    /// The subclass may transfer this partial word in a full word transfer, but it must be careful to only use the defined bits.
     /// inBuffer_ is a multiple of largest word size, so this full word transfer off the end will always be in defined memory.
 
     size_t firstWord       = inBufferFirstBit_ / bitsPerWord_;
@@ -7607,7 +7607,7 @@ size_t BitpackFloatDecoder::inputProcessAligned(const char* inbuf, const size_t 
     for (unsigned i = 0; i < n; i++)
     {
       float value = *inp;
-      SWAB(&value); /// swab if neccesary
+      SWAB(&value); /// swab if necessary
 #ifdef E57_MAX_VERBOSE
       cout << "  got float value=" << value << endl;
 #endif
@@ -7624,7 +7624,7 @@ size_t BitpackFloatDecoder::inputProcessAligned(const char* inbuf, const size_t 
     for (unsigned i = 0; i < n; i++)
     {
       double value = *inp;
-      SWAB(&value); /// swab if neccesary
+      SWAB(&value); /// swab if necessary
 #ifdef E57_MAX_VERBOSE
       cout << "  got double value=" << value << endl;
 #endif
@@ -8012,7 +8012,7 @@ void PacketReadCache::readPacket(unsigned oldestEntry, uint64_t packetLogicalOff
   cout << "PacketReadCache::readPacket() called, oldestEntry=" << oldestEntry << " packetLogicalOffset=" << packetLogicalOffset << endl;
 #endif
 
-  /// Read header of packet first to get length.  Use EmptyPacketHeader since it has the commom fields to all packets.
+  /// Read header of packet first to get length.  Use EmptyPacketHeader since it has the common fields to all packets.
   EmptyPacketHeader header;
   cFile_->seek(packetLogicalOffset, CheckedFile::logical);
   cFile_->read(reinterpret_cast<char*>(&header), sizeof(header));
@@ -8294,7 +8294,7 @@ uint64_t BitpackIntegerEncoder<RegisterT>::processRecords(size_t recordCount)
       }
 #endif
       outp[outTransferred] = register_;
-      SWAB(&outp[outTransferred]); /// swab if neccesary
+      SWAB(&outp[outTransferred]); /// swab if necessary
       outTransferred++;
 
       register_         = 0;
@@ -8590,7 +8590,7 @@ size_t BitpackIntegerDecoder<RegisterT>::inputProcessAligned(const char* inbuf, 
     else
       destBuffer_->setNextInt64(value);
 
-    /// Store the result in next avaiable position in the user's dest buffer
+    /// Store the result in next available position in the user's dest buffer
 
     /// Calc next bit alignment and which word it starts in
     bitOffset += bitsPerRecord_;

--- a/src/lib/src/openE57Impl.cpp
+++ b/src/lib/src/openE57Impl.cpp
@@ -828,7 +828,7 @@ void StructureNodeImpl::writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile
   /// don't checkImageFileOpen
 
   ustring fieldName;
-  if (forcedFieldName != NULL)
+  if (forcedFieldName != nullptr)
     fieldName = forcedFieldName;
   else
     fieldName = elementName_;
@@ -964,7 +964,7 @@ void VectorNodeImpl::writeXml(std::shared_ptr<ImageFileImpl> imf, CheckedFile& c
   /// don't checkImageFileOpen
 
   ustring fieldName;
-  if (forcedFieldName != NULL)
+  if (forcedFieldName != nullptr)
     fieldName = forcedFieldName;
   else
     fieldName = elementName_;
@@ -1089,7 +1089,7 @@ SourceDestBufferImpl::SourceDestBufferImpl(std::weak_ptr<ImageFileImpl> destImag
   /// don't checkImageFileOpen, checkState_ will do it
 
   /// Set capacity_ after testing that b is OK
-  if (b == NULL)
+  if (b == nullptr)
     throw E57_EXCEPTION2(E57_ERROR_BAD_BUFFER, "sdbuf.pathName=" + pathName);
   capacity_ = b->size();
 
@@ -1113,7 +1113,7 @@ void SourceDestBufferImpl::checkState_()
 
   if (memoryRepresentation_ != E57_USTRING)
   {
-    if (base_ == NULL)
+    if (base_ == nullptr)
       throw E57_EXCEPTION2(E57_ERROR_BAD_BUFFER, "pathName=" + pathName_);
     if (stride_ == 0)
       throw E57_EXCEPTION2(E57_ERROR_BAD_BUFFER, "pathName=" + pathName_);
@@ -1122,7 +1122,7 @@ void SourceDestBufferImpl::checkState_()
   }
   else
   {
-    if (ustrings_ == NULL)
+    if (ustrings_ == nullptr)
       throw E57_EXCEPTION2(E57_ERROR_BAD_BUFFER, "pathName=" + pathName_);
   }
 }
@@ -2033,7 +2033,7 @@ void CompressedVectorNodeImpl::writeXml(std::shared_ptr<ImageFileImpl> imf, Chec
   // don't checkImageFileOpen
 
   ustring fieldName;
-  if (forcedFieldName != NULL)
+  if (forcedFieldName != nullptr)
     fieldName = forcedFieldName;
   else
     fieldName = elementName_;
@@ -2250,7 +2250,7 @@ void IntegerNodeImpl::writeXml(std::shared_ptr<ImageFileImpl> /*imf???*/, Checke
   // don't checkImageFileOpen
 
   ustring fieldName;
-  if (forcedFieldName != NULL)
+  if (forcedFieldName != nullptr)
     fieldName = forcedFieldName;
   else
     fieldName = elementName_;
@@ -2421,7 +2421,7 @@ void ScaledIntegerNodeImpl::writeXml(std::shared_ptr<ImageFileImpl> /*imf*/, Che
   // don't checkImageFileOpen
 
   ustring fieldName;
-  if (forcedFieldName != NULL)
+  if (forcedFieldName != nullptr)
     fieldName = forcedFieldName;
   else
     fieldName = elementName_;
@@ -2568,7 +2568,7 @@ void FloatNodeImpl::writeXml(std::shared_ptr<ImageFileImpl> /*imf*/, CheckedFile
   // don't checkImageFileOpen
 
   ustring fieldName;
-  if (forcedFieldName != NULL)
+  if (forcedFieldName != nullptr)
     fieldName = forcedFieldName;
   else
     fieldName = elementName_;
@@ -2690,7 +2690,7 @@ void StringNodeImpl::writeXml(std::shared_ptr<ImageFileImpl> /*imf*/, CheckedFil
   // don't checkImageFileOpen
 
   ustring fieldName;
-  if (forcedFieldName != NULL)
+  if (forcedFieldName != nullptr)
     fieldName = forcedFieldName;
   else
     fieldName = elementName_;
@@ -2891,7 +2891,7 @@ void BlobNodeImpl::writeXml(std::shared_ptr<ImageFileImpl> /*imf*/, CheckedFile&
   // don't checkImageFileOpen
 
   ustring fieldName;
-  if (forcedFieldName != NULL)
+  if (forcedFieldName != nullptr)
     fieldName = forcedFieldName;
   else
     fieldName = elementName_;
@@ -3178,7 +3178,7 @@ void E57XmlParser::startElement(const XMLCh* const uri, const XMLCh* const local
 #if defined(_MSC_VER)
       pi.minimum = _atoi64(minimum_str.c_str());
 #elif defined(__GNUC__)
-      pi.minimum = strtoll(minimum_str.c_str(), NULL, 10);          //??? check endptr?
+      pi.minimum = strtoll(minimum_str.c_str(), nullptr, 10);       //??? check endptr?
 #else
 #  error "no supported compiler defined"
 #endif
@@ -3195,7 +3195,7 @@ void E57XmlParser::startElement(const XMLCh* const uri, const XMLCh* const local
 #if defined(_MSC_VER)
       pi.maximum = _atoi64(maximum_str.c_str());
 #elif defined(__GNUC__)
-      pi.maximum = strtoll(maximum_str.c_str(), NULL, 10);          //??? check endptr?
+      pi.maximum = strtoll(maximum_str.c_str(), nullptr, 10);       //??? check endptr?
 #else
 #  error "no supported compiler defined"
 #endif
@@ -3223,7 +3223,7 @@ void E57XmlParser::startElement(const XMLCh* const uri, const XMLCh* const local
 #if defined(_MSC_VER)
       pi.minimum = _atoi64(minimum_str.c_str());
 #elif defined(__GNUC__)
-      pi.minimum = strtoll(minimum_str.c_str(), NULL, 10);          //??? check endptr?
+      pi.minimum = strtoll(minimum_str.c_str(), nullptr, 10);       //??? check endptr?
 #else
 #  error "no supported compiler defined"
 #endif
@@ -3240,7 +3240,7 @@ void E57XmlParser::startElement(const XMLCh* const uri, const XMLCh* const local
 #if defined(_MSC_VER)
       pi.maximum = _atoi64(maximum_str.c_str());
 #elif defined(__GNUC__)
-      pi.maximum = strtoll(maximum_str.c_str(), NULL, 10);          //??? check endptr?
+      pi.maximum = strtoll(maximum_str.c_str(), nullptr, 10);       //??? check endptr?
 #else
 #  error "no supported compiler defined"
 #endif
@@ -3357,7 +3357,7 @@ void E57XmlParser::startElement(const XMLCh* const uri, const XMLCh* const local
 #if defined(_MSC_VER)
     pi.fileOffset = _atoi64(fileOffset_str.c_str());
 #elif defined(__GNUC__)
-    pi.fileOffset = strtoll(fileOffset_str.c_str(), NULL, 10);      //??? check endptr?
+    pi.fileOffset = strtoll(fileOffset_str.c_str(), nullptr, 10);   //??? check endptr?
 #else
 #  error "no supported compiler defined"
 #endif
@@ -3367,7 +3367,7 @@ void E57XmlParser::startElement(const XMLCh* const uri, const XMLCh* const local
 #if defined(_MSC_VER)
     pi.length = _atoi64(length_str.c_str());
 #elif defined(__GNUC__)
-    pi.length     = strtoll(length_str.c_str(), NULL, 10);          //??? check endptr?
+    pi.length     = strtoll(length_str.c_str(), nullptr, 10);       //??? check endptr?
 #else
 #  error "no supported compiler defined"
 #endif
@@ -3441,7 +3441,7 @@ void E57XmlParser::startElement(const XMLCh* const uri, const XMLCh* const local
 #if defined(_MSC_VER)
       int64_t i64 = _atoi64(allowHetero_str.c_str());
 #elif defined(__GNUC__)
-      int64_t i64 = strtoll(allowHetero_str.c_str(), NULL, 10); //??? check endptr?
+      int64_t i64 = strtoll(allowHetero_str.c_str(), nullptr, 10);  //??? check endptr?
 #else
 #  error "no supported compiler defined"
 #endif
@@ -3480,7 +3480,7 @@ void E57XmlParser::startElement(const XMLCh* const uri, const XMLCh* const local
 #if defined(_MSC_VER)
     pi.fileOffset = _atoi64(fileOffset_str.c_str());
 #elif defined(__GNUC__)
-    pi.fileOffset  = strtoll(fileOffset_str.c_str(), NULL, 10);     //??? check endptr?
+    pi.fileOffset  = strtoll(fileOffset_str.c_str(), nullptr, 10);  //??? check endptr?
 #else
 #  error "no supported compiler defined"
 #endif
@@ -3490,7 +3490,7 @@ void E57XmlParser::startElement(const XMLCh* const uri, const XMLCh* const local
 #if defined(_MSC_VER)
     pi.recordCount = _atoi64(recordCount_str.c_str());
 #elif defined(__GNUC__)
-    pi.recordCount = strtoll(recordCount_str.c_str(), NULL, 10);    //??? check endptr?
+    pi.recordCount = strtoll(recordCount_str.c_str(), nullptr, 10); //??? check endptr?
 #else
 #  error "no supported compiler defined"
 #endif
@@ -3498,7 +3498,7 @@ void E57XmlParser::startElement(const XMLCh* const uri, const XMLCh* const local
     /// Create container now, so can hold children
     std::shared_ptr<CompressedVectorNodeImpl> cv_ni(new CompressedVectorNodeImpl(imf_));
     cv_ni->setRecordCount(pi.recordCount);
-    cv_ni->setBinarySectionLogicalStart(imf_->file_->physicalToLogical(pi.fileOffset)); //??? what if file_ is NULL?
+    cv_ni->setBinarySectionLogicalStart(imf_->file_->physicalToLogical(pi.fileOffset)); //??? what if file_ is nullptr?
     pi.container_ni = cv_ni;
 
     /// Push info so far onto stack
@@ -3548,7 +3548,7 @@ void E57XmlParser::endElement(const XMLCh* const uri, const XMLCh* const localNa
 #if defined(_MSC_VER)
       intValue = _atoi64(pi.childText.c_str());
 #elif defined(__GNUC__)
-      intValue = strtoll(pi.childText.c_str(), NULL, 10);           //??? check endptr?
+      intValue = strtoll(pi.childText.c_str(), nullptr, 10);        //??? check endptr?
 #else
 #  error "no supported compiler defined"
 #endif
@@ -3567,7 +3567,7 @@ void E57XmlParser::endElement(const XMLCh* const uri, const XMLCh* const localNa
 #if defined(_MSC_VER)
       intValue = _atoi64(pi.childText.c_str());
 #elif defined(__GNUC__)
-      intValue = strtoll(pi.childText.c_str(), NULL, 10);           //??? check endptr?
+      intValue = strtoll(pi.childText.c_str(), nullptr, 10);        //??? check endptr?
 #else
 #  error "no supported compiler defined"
 #endif
@@ -3806,7 +3806,7 @@ void ImageFileImpl::construct2(const ustring& fileName, const ustring& mode, con
     throw E57_EXCEPTION2(E57_ERROR_BAD_API_ARGUMENT, "mode=" + ustring(mode));
 
   /// If mode is read, do it
-  file_ = NULL;
+  file_ = nullptr;
   if (!isWriter_)
   {
     try
@@ -3828,15 +3828,15 @@ void ImageFileImpl::construct2(const ustring& fileName, const ustring& mode, con
     catch (...)
     {
       /// Remember to close file if got any exception
-      if (file_ != NULL)
+      if (file_ != nullptr)
       {
         delete file_;
-        file_ = NULL;
+        file_ = nullptr;
       }
       throw; // rethrow
     }
 
-    SAX2XMLReader* xmlReader = NULL;
+    SAX2XMLReader* xmlReader = nullptr;
 
     // Initialize the XML4C2 system
     try
@@ -3876,15 +3876,15 @@ void ImageFileImpl::construct2(const ustring& fileName, const ustring& mode, con
     }
     catch (...)
     {
-      if (xmlReader != NULL)
+      if (xmlReader != nullptr)
       {
         delete xmlReader;
-        xmlReader = NULL;
+        xmlReader = nullptr;
       }
-      if (file_ != NULL)
+      if (file_ != nullptr)
       {
         delete file_;
-        file_ = NULL;
+        file_ = nullptr;
       }
       throw; // rethrow
     }
@@ -3910,10 +3910,10 @@ void ImageFileImpl::construct2(const ustring& fileName, const ustring& mode, con
     catch (...)
     {
       /// Remember to close file if got any exception
-      if (file_ != NULL)
+      if (file_ != nullptr)
       {
         delete file_;
-        file_ = NULL;
+        file_ = nullptr;
       }
       throw; // rethrow
     }
@@ -4011,7 +4011,7 @@ void ImageFileImpl::close()
   //??? flush, close
 
   /// If file already closed, have nothing to do
-  if (file_ == NULL)
+  if (file_ == nullptr)
     return;
 
   if (isWriter_)
@@ -4058,13 +4058,13 @@ void ImageFileImpl::close()
   }
 
   delete file_;
-  file_ = NULL;
+  file_ = nullptr;
 }
 
 void ImageFileImpl::cancel()
 {
   /// If file already closed, have nothing to do
-  if (file_ == NULL)
+  if (file_ == nullptr)
     return;
 
   /// Close the file and ulink (delete) it.
@@ -4075,12 +4075,12 @@ void ImageFileImpl::cancel()
     file_->close();
 
   delete file_;
-  file_ = NULL;
+  file_ = nullptr;
 }
 
 bool ImageFileImpl::isOpen()
 {
-  return (file_ != NULL);
+  return (file_ != nullptr);
 }
 
 bool ImageFileImpl::isWriter()
@@ -4110,10 +4110,10 @@ ImageFileImpl::~ImageFileImpl()
   {};
 
   /// Just in case cancel failed without freeing file_, do free here.
-  if (file_ != NULL)
+  if (file_ != nullptr)
   {
     delete file_;
-    file_ = NULL;
+    file_ = nullptr;
   }
 }
 
@@ -6354,7 +6354,7 @@ CompressedVectorReaderImpl::CompressedVectorReaderImpl(std::shared_ptr<Compresse
 
   /// Verify that packet given by dataPhysicalOffset is actually a data packet, init channels
   {
-    char*                       anyPacket  = NULL;
+    char*                       anyPacket  = nullptr;
     std::unique_ptr<PacketLock> packetLock = cache_->lock(dataLogicalOffset, anyPacket);
 
     DataPacket* dpkt = reinterpret_cast<DataPacket*>(anyPacket);
@@ -6455,7 +6455,7 @@ unsigned CompressedVectorReaderImpl::read()
   /// Allow decoders to use data they already have in their queue to fill newly empty dbufs
   /// This helps to keep decoder input queues smaller, which reduces backtracking in the packet cache.
   for (unsigned i = 0; i < channels_.size(); i++)
-    channels_[i].decoder->inputProcess(NULL, 0);
+    channels_[i].decoder->inputProcess(nullptr, 0);
 
   /// Loop until every dbuf is full or we have reached end of the binary section.
   while (1)
@@ -6520,7 +6520,7 @@ void CompressedVectorReaderImpl::feedPacketToDecoders(uint64_t currentPacketLogi
   uint64_t nextPacketLogicalOffset   = E57_UINT64_MAX;
   {
     /// Get packet at currentPacketLogicalOffset into memory.
-    char*                       anyPacket  = NULL;
+    char*                       anyPacket  = nullptr;
     std::unique_ptr<PacketLock> packetLock = cache_->lock(currentPacketLogicalOffset, anyPacket);
     DataPacket*                 dpkt       = reinterpret_cast<DataPacket*>(anyPacket);
 
@@ -6589,7 +6589,7 @@ void CompressedVectorReaderImpl::feedPacketToDecoders(uint64_t currentPacketLogi
     if (nextPacketLogicalOffset < E57_UINT64_MAX)
     { //??? huh?
       /// Get packet at nextPacketLogicalOffset into memory.
-      char*                       anyPacket  = NULL;
+      char*                       anyPacket  = nullptr;
       std::unique_ptr<PacketLock> packetLock = cache_->lock(nextPacketLogicalOffset, anyPacket);
       DataPacket*                 dpkt       = reinterpret_cast<DataPacket*>(anyPacket);
 
@@ -6646,7 +6646,7 @@ uint64_t CompressedVectorReaderImpl::findNextDataPacket(uint64_t nextPacketLogic
   /// Starting at nextPacketLogicalOffset, search for next data packet until hit end of binary section.
   while (nextPacketLogicalOffset < sectionEndLogicalOffset_)
   {
-    char*                       anyPacket  = NULL;
+    char*                       anyPacket  = nullptr;
     std::unique_ptr<PacketLock> packetLock = cache_->lock(nextPacketLogicalOffset, anyPacket);
 
     /// Guess it's a data packet, if not continue to next packet
@@ -6702,7 +6702,7 @@ void CompressedVectorReaderImpl::close()
   channels_.clear();
 
   delete cache_;
-  cache_ = NULL;
+  cache_ = nullptr;
 
   isOpen_ = false;
 }
@@ -7910,7 +7910,7 @@ PacketReadCache::~PacketReadCache()
   for (unsigned i = 0; i < entries_.size(); i++)
   {
     delete[] entries_.at(i).buffer_;
-    entries_.at(i).buffer_ = NULL;
+    entries_.at(i).buffer_ = nullptr;
   }
 }
 

--- a/src/lib/src/openE57Impl.cpp
+++ b/src/lib/src/openE57Impl.cpp
@@ -2986,7 +2986,7 @@ XMLSize_t E57FileInputStream::readBytes(XMLByte* const toFill, const XMLSize_t m
   else
   {
     /// size_t is smaller than int64_t, Calc max that size_t can hold
-    const int64_t size_max = std::numeric_limits<size_t>::max();
+    constexpr int64_t size_max = std::numeric_limits<size_t>::max();
 
     /// read smaller of size_max, available
     ///??? redo

--- a/src/lib/src/openE57Simple.cpp
+++ b/src/lib/src/openE57Simple.cpp
@@ -140,27 +140,27 @@ An example of a typical use of this interface would be as follows:
 
 //Setup buffers
 
-   int8_t * isInvalidData = NULL;
+   int8_t * isInvalidData = nullptr;
    if(scanHeader.pointFields.cartesianInvalidStateField)
      isInvalidData = new int8_t[nSize];
 
 //Setup Points Buffers
 
-   double * xData = NULL;
+   double * xData = nullptr;
    if(scanHeader.pointFields.cartesianXField)
      xData = new double[nSize];
 
-   double * yData = NULL;
+   double * yData = nullptr;
    if(scanHeader.pointFields.cartesianYField)
      yData = new double[nSize];
 
-   double * zData = NULL;
+   double * zData = nullptr;
    if(scanHeader.pointFields.cartesianZField)
      zData = new double[nSize];
 
 //Setup intensity buffers if present
 
-   double *	intData = NULL;
+   double *	intData = nullptr;
    bool		bIntensity = false;
    double		intRange = 0;
    double		intOffset = 0;
@@ -175,9 +175,9 @@ An example of a typical use of this interface would be as follows:
 
 //Setup color buffers if present
 
-   uint16_t *	redData = NULL;
-   uint16_t *	greenData = NULL;
-   uint16_t *	blueData = NULL;
+   uint16_t *	redData = nullptr;
+   uint16_t *	greenData = nullptr;
+   uint16_t *	blueData = nullptr;
    bool		bColor = false;
    int32_t		colorRedRange = 1;
    int32_t		colorRedOffset = 0;
@@ -202,9 +202,9 @@ An example of a typical use of this interface would be as follows:
 
 //Setup the GroupByLine buffers information
 
-   int64_t * idElementValue = NULL;
-   int64_t * startPointIndex = NULL;
-   int64_t * pointCount = NULL;
+   int64_t * idElementValue = nullptr;
+   int64_t * startPointIndex = nullptr;
+   int64_t * pointCount = nullptr;
    if(nGroupsSize > 0)
    {
      idElementValue = new int64_t[nGroupsSize];
@@ -218,8 +218,8 @@ An example of a typical use of this interface would be as follows:
 
 //Setup row/column index information
 
-   int32_t * rowIndex = NULL;
-   int32_t * columnIndex = NULL;
+   int32_t * rowIndex = nullptr;
+   int32_t * columnIndex = nullptr;
    if(scanHeader.pointFields.rowIndexField)
      rowIndex = new int32_t[nSize];
    if(scanHeader.pointFields.columnIndexField)
@@ -235,14 +235,14 @@ An example of a typical use of this interface would be as follows:
        zData,				//!< pointer to a buffer with the z data
        isInvalidData,		//!< pointer to a buffer with the valid indication
        intData,			//!< pointer to a buffer with the lidar return intesity
-       NULL,
+       nullptr,
        redData,			//!< pointer to a buffer with the color red data
        greenData,			//!< pointer to a buffer with the color green data
        blueData,			//!< pointer to a buffer with the color blue data
-       NULL,
-       NULL,
-       NULL,
-       NULL,
+       nullptr,
+       nullptr,
+       nullptr,
+       nullptr,
        rowIndex,			//!< pointer to a buffer with the rowIndex
        columnIndex			//!< pointer to a buffer with the columnIndex
        );
@@ -519,9 +519,9 @@ An example of a typical use of this interface would be as follows:
 
 //Setup Color
 
-   uint16_t * redData = NULL;
-   uint16_t * greenData = NULL;
-   uint16_t * blueData = NULL;
+   uint16_t * redData = nullptr;
+   uint16_t * greenData = nullptr;
+   uint16_t * blueData = nullptr;
    if(exportColor)
    {
      scanHeader.pointFields.colorRedField = true;
@@ -541,7 +541,7 @@ An example of a typical use of this interface would be as follows:
 
 //Setup Intensity
 
-   double * intData = NULL;
+   double * intData = nullptr;
    if(exportIntensity)
    {
      scanHeader.pointFields.intensityField = true;
@@ -566,11 +566,11 @@ An example of a typical use of this interface would be as follows:
        zData,				//!< pointer to a buffer with the z data
        isInvalidData,		//!< pointer to a buffer with the valid indication
        intData,			//!< pointer to a buffer with the lidar return intesity
-       NULL,
+       nullptr,
        redData,			//!< pointer to a buffer with the color red data
        greenData,			//!< pointer to a buffer with the color green data
        blueData,			//!< pointer to a buffer with the color blue data
-       NULL
+       nullptr
        );
 
 /////////////////////////////////////////////////////////////////

--- a/src/lib/src/openE57Simple.cpp
+++ b/src/lib/src/openE57Simple.cpp
@@ -373,7 +373,7 @@ An example of a typical use of this interface would be as follows:
 
 //Read the picture data
 
-   eReader.ReadImage2DData(imageIndex, imageProjection, imageType, jpegBuffer, 0, nImagesSizw);
+   eReader.ReadImage2DData(imageIndex, imageProjection, imageType, jpegBuffer, 0, nImagesSize);
 
 // ... access the picture and decode ...
 
@@ -381,7 +381,7 @@ An example of a typical use of this interface would be as follows:
 
    delete jpegBuffer;
 
-   eReaer.Close();
+   eReader.Close();
 
 ///////////////////////////////////////////////////////////////////////
 // CATCH THE ERRORS
@@ -565,7 +565,7 @@ An example of a typical use of this interface would be as follows:
        yData,				//!< pointer to a buffer with the y data
        zData,				//!< pointer to a buffer with the z data
        isInvalidData,		//!< pointer to a buffer with the valid indication
-       intData,			//!< pointer to a buffer with the lidar return intesity
+       intData,			//!< pointer to a buffer with the lidar return intensity
        nullptr,
        redData,			//!< pointer to a buffer with the color red data
        greenData,			//!< pointer to a buffer with the color green data
@@ -1129,7 +1129,7 @@ VectorNode Reader ::GetRawImages2D(void)
 
 bool Reader ::ReadData3D(int32_t dataIndex,   // This in the index into the images3D vector
                          Data3D& data3DHeader // pointer to the Data3D structure to receive the image information
-) const                                       // /return Returns true if sucessful
+) const                                       // /return Returns true if successful
 {
   return impl_->ReadData3D(dataIndex, data3DHeader);
 }
@@ -1138,7 +1138,7 @@ bool Reader ::GetData3DSizes(int32_t  dataIndex,   // This in the index into the
                              int64_t& rowMax,      // This is the maximum row size
                              int64_t& columnMax,   // This is the maximum column size
                              int64_t& pointsSize,  // This is the total number of point records
-                             int64_t& groupsSize,  // This is the total number of group reocrds
+                             int64_t& groupsSize,  // This is the total number of group records
                              int64_t& countSize,   //!< This is the maximum point count per group
                              bool&    bColumnIndex //!< This indicates that the idElementName is "columnIndex"
 ) const
@@ -1151,7 +1151,7 @@ bool Reader ::ReadData3DGroupsData(int32_t  dataIndex,       // data block index
                                    int64_t* idElementValue,  // index for this group
                                    int64_t* startPointIndex, // Starting index in to the "points" data vector for the groups
                                    int64_t* pointCount       // size of the groups given
-) const                                                      // \return Return true if sucessful, false otherwise
+) const                                                      // \return Return true if successful, false otherwise
 {
   return impl_->ReadData3DGroupsData(dataIndex, groupCount, idElementValue, startPointIndex, pointCount);
 }
@@ -1312,7 +1312,7 @@ bool Writer ::WriteData3DGroupsData(int32_t  dataIndex,       // data block inde
                                     int64_t* idElementValue,  // index for this group
                                     int64_t* startPointIndex, // Starting index in to the "points" data vector for the groups
                                     int64_t* pointCount       // size of the groups given
-) const                                                       // \return Return true if sucessful, false otherwise
+) const                                                       // \return Return true if successful, false otherwise
 {
   return impl_->WriteData3DGroupsData(dataIndex, groupCount, idElementValue, startPointIndex, pointCount);
 }

--- a/src/lib/src/openE57SimpleImpl.cpp
+++ b/src/lib/src/openE57SimpleImpl.cpp
@@ -390,7 +390,7 @@ int32_t ReaderImpl ::GetImage2DCount(void)
 //! This function returns the Image2Ds header and positions the cursor
 bool ReaderImpl ::ReadImage2D(int32_t  imageIndex,   //!< This in the index into the Image2Ds vector
                               Image2D& image2DHeader //!< pointer to the Image2D structure to receive the picture information
-                              )                      //!< /return Returns true if sucessful
+                              )                      //!< /return Returns true if successful
 {
   if (IsOpen())
   {
@@ -755,7 +755,7 @@ ImageFile ReaderImpl ::GetRawIMF(void)
 //! This function returns the Data3D header and positions the cursor
 bool ReaderImpl ::ReadData3D(int32_t dataIndex,   //!< This in the index into the images3D vector
                              Data3D& data3DHeader //!< pointer to the Data3D structure to receive the image information
-                             )                    //!< /return Returns true if sucessful
+                             )                    //!< /return Returns true if successful
 {
   if (IsOpen())
   {
@@ -1354,7 +1354,7 @@ bool ReaderImpl ::ReadData3DGroupsData(int32_t  dataIndex,       //!< data block
                                        int64_t* idElementValue,  //!< index for this group
                                        int64_t* startPointIndex, //!< Starting index in to the "points" data vector for the groups
                                        int64_t* pointCount       //!< size of the groups given
-                                       )                         //!< \return Return true if sucessful, false otherwise
+                                       )                         //!< \return Return true if successful, false otherwise
 {
   if ((dataIndex < 0) || (dataIndex >= data3D_.childCount()))
     return false;
@@ -1516,7 +1516,7 @@ WriterImpl::WriterImpl(const ustring& filePath, const ustring& coordinateMetadat
 {
   /// We are using the E57 v1.0 data format standard fieldnames.
   /// The standard fieldnames are used without an extension prefix (in the default namespace).
-  /// We explicitly register it for completeness (the reference implementaion would do it for us, if we didn't).
+  /// We explicitly register it for completeness (the reference implementation would do it for us, if we didn't).
   imf_.extensionsAdd("", E57_V1_0_URI);
 
 #ifdef TEST_EXTENSIONS
@@ -2425,7 +2425,7 @@ bool WriterImpl ::WriteData3DGroupsData(int32_t  dataIndex,       //!< data bloc
                                         int64_t* idElementValue,  //!< index for this group
                                         int64_t* startPointIndex, //!< Starting index in to the "points" data vector for the groups
                                         int64_t* pointCount       //!< size of each of the groups given
-                                        )                         //!< \return Return true if sucessful, false otherwise
+                                        )                         //!< \return Return true if successful, false otherwise
 {
   if ((dataIndex < 0) || (dataIndex >= data3D_.childCount()))
     return false;

--- a/src/lib/src/openE57SimpleImpl.cpp
+++ b/src/lib/src/openE57SimpleImpl.cpp
@@ -1379,13 +1379,13 @@ bool ReaderImpl ::ReadData3DGroupsData(int32_t  dataIndex,       //!< data block
       {
         ustring name = lineGroupRecord.get(protoIndex).elementName();
 
-        if ((name.compare("idElementValue") == 0) && lineGroupRecord.isDefined("idElementValue") && (idElementValue != NULL))
+        if ((name.compare("idElementValue") == 0) && lineGroupRecord.isDefined("idElementValue") && (idElementValue != nullptr))
           groupSDBuffers.push_back(SourceDestBuffer(imf_, "idElementValue", idElementValue, (unsigned)groupCount, true));
 
-        if ((name.compare("startPointIndex") == 0) && lineGroupRecord.isDefined("startPointIndex") && (startPointIndex != NULL))
+        if ((name.compare("startPointIndex") == 0) && lineGroupRecord.isDefined("startPointIndex") && (startPointIndex != nullptr))
           groupSDBuffers.push_back(SourceDestBuffer(imf_, "startPointIndex", startPointIndex, (unsigned)groupCount, true));
 
-        if ((name.compare("pointCount") == 0) && lineGroupRecord.isDefined("pointCount") && (pointCount != NULL))
+        if ((name.compare("pointCount") == 0) && lineGroupRecord.isDefined("pointCount") && (pointCount != nullptr))
           groupSDBuffers.push_back(SourceDestBuffer(imf_, "pointCount", pointCount, (unsigned)groupCount, true));
       }
 
@@ -1400,7 +1400,7 @@ bool ReaderImpl ::ReadData3DGroupsData(int32_t  dataIndex,       //!< data block
 }
 
 //! This function returns the point data fields fetched in single call
-//* All the non-NULL buffers in the call below have number of elements = count */
+//* All the non-nullptr buffers in the call below have number of elements = count */
 
 CompressedVectorReader ReaderImpl ::SetUpData3DPointsData(
   int32_t dataIndex, int64_t count,
@@ -1451,52 +1451,52 @@ CompressedVectorReader ReaderImpl ::SetUpData3DPointsData(
     NodeType type   = proto.get(protoIndex).type();
     bool     scaled = type == NodeType::E57_SCALED_INTEGER ? true : false;
 
-    if ((name.compare("cartesianX") == 0) && proto.isDefined("cartesianX") && (cartesianX != NULL))
+    if ((name.compare("cartesianX") == 0) && proto.isDefined("cartesianX") && (cartesianX != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "cartesianX", cartesianX, (unsigned)count, true, scaled));
-    else if ((name.compare("cartesianY") == 0) && proto.isDefined("cartesianY") && (cartesianY != NULL))
+    else if ((name.compare("cartesianY") == 0) && proto.isDefined("cartesianY") && (cartesianY != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "cartesianY", cartesianY, (unsigned)count, true, scaled));
-    else if ((name.compare("cartesianZ") == 0) && proto.isDefined("cartesianZ") && (cartesianZ != NULL))
+    else if ((name.compare("cartesianZ") == 0) && proto.isDefined("cartesianZ") && (cartesianZ != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "cartesianZ", cartesianZ, (unsigned)count, true, scaled));
-    else if ((name.compare("cartesianInvalidState") == 0) && proto.isDefined("cartesianInvalidState") && (cartesianInvalidState != NULL))
+    else if ((name.compare("cartesianInvalidState") == 0) && proto.isDefined("cartesianInvalidState") && (cartesianInvalidState != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "cartesianInvalidState", cartesianInvalidState, (unsigned)count, true));
 
-    else if ((name.compare("sphericalRange") == 0) && proto.isDefined("sphericalRange") && (sphericalRange != NULL))
+    else if ((name.compare("sphericalRange") == 0) && proto.isDefined("sphericalRange") && (sphericalRange != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "sphericalRange", sphericalRange, (unsigned)count, true, scaled));
-    else if ((name.compare("sphericalAzimuth") == 0) && proto.isDefined("sphericalAzimuth") && (sphericalAzimuth != NULL))
+    else if ((name.compare("sphericalAzimuth") == 0) && proto.isDefined("sphericalAzimuth") && (sphericalAzimuth != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "sphericalAzimuth", sphericalAzimuth, (unsigned)count, true, scaled));
-    else if ((name.compare("sphericalElevation") == 0) && proto.isDefined("sphericalElevation") && (sphericalElevation != NULL))
+    else if ((name.compare("sphericalElevation") == 0) && proto.isDefined("sphericalElevation") && (sphericalElevation != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "sphericalElevation", sphericalElevation, (unsigned)count, true, scaled));
-    else if ((name.compare("sphericalInvalidState") == 0) && proto.isDefined("sphericalInvalidState") && (sphericalInvalidState != NULL))
+    else if ((name.compare("sphericalInvalidState") == 0) && proto.isDefined("sphericalInvalidState") && (sphericalInvalidState != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "sphericalInvalidState", sphericalInvalidState, (unsigned)count, true));
 
-    else if ((name.compare("rowIndex") == 0) && proto.isDefined("rowIndex") && (rowIndex != NULL))
+    else if ((name.compare("rowIndex") == 0) && proto.isDefined("rowIndex") && (rowIndex != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "rowIndex", rowIndex, (unsigned)count, true));
-    else if ((name.compare("columnIndex") == 0) && proto.isDefined("columnIndex") && (columnIndex != NULL))
+    else if ((name.compare("columnIndex") == 0) && proto.isDefined("columnIndex") && (columnIndex != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "columnIndex", columnIndex, (unsigned)count, true));
-    else if ((name.compare("returnIndex") == 0) && proto.isDefined("returnIndex") && (returnIndex != NULL))
+    else if ((name.compare("returnIndex") == 0) && proto.isDefined("returnIndex") && (returnIndex != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "returnIndex", returnIndex, (unsigned)count, true));
-    else if ((name.compare("returnCount") == 0) && proto.isDefined("returnCount") && (returnCount != NULL))
+    else if ((name.compare("returnCount") == 0) && proto.isDefined("returnCount") && (returnCount != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "returnCount", returnCount, (unsigned)count, true));
 
-    else if ((name.compare("timeStamp") == 0) && proto.isDefined("timeStamp") && (timeStamp != NULL))
+    else if ((name.compare("timeStamp") == 0) && proto.isDefined("timeStamp") && (timeStamp != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "timeStamp", timeStamp, (unsigned)count, true, scaled));
-    else if ((name.compare("isTimeStampInvalid") == 0) && proto.isDefined("isTimeStampInvalid") && (isTimeStampInvalid != NULL))
+    else if ((name.compare("isTimeStampInvalid") == 0) && proto.isDefined("isTimeStampInvalid") && (isTimeStampInvalid != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "isTimeStampInvalid", isTimeStampInvalid, (unsigned)count, true));
 
-    else if ((name.compare("intensity") == 0) && proto.isDefined("intensity") && (intensity != NULL))
+    else if ((name.compare("intensity") == 0) && proto.isDefined("intensity") && (intensity != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "intensity", intensity, (unsigned)count, true, scaled));
-    else if ((name.compare("isIntensityInvalid") == 0) && proto.isDefined("isIntensityInvalid") && (isIntensityInvalid != NULL))
+    else if ((name.compare("isIntensityInvalid") == 0) && proto.isDefined("isIntensityInvalid") && (isIntensityInvalid != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "isIntensityInvalid", isIntensityInvalid, (unsigned)count, true));
 
-    else if ((name.compare("colorRed") == 0) && proto.isDefined("colorRed") && (colorRed != NULL))
+    else if ((name.compare("colorRed") == 0) && proto.isDefined("colorRed") && (colorRed != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "colorRed", colorRed, (unsigned)count, true, scaled));
-    else if ((name.compare("colorGreen") == 0) && proto.isDefined("colorGreen") && (colorGreen != NULL))
+    else if ((name.compare("colorGreen") == 0) && proto.isDefined("colorGreen") && (colorGreen != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "colorGreen", colorGreen, (unsigned)count, true, scaled));
-    else if ((name.compare("colorBlue") == 0) && proto.isDefined("colorBlue") && (colorBlue != NULL))
+    else if ((name.compare("colorBlue") == 0) && proto.isDefined("colorBlue") && (colorBlue != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "colorBlue", colorBlue, (unsigned)count, true, scaled));
-    else if ((name.compare("isColorInvalid") == 0) && proto.isDefined("isColorInvalid") && (isColorInvalid != NULL))
+    else if ((name.compare("isColorInvalid") == 0) && proto.isDefined("isColorInvalid") && (isColorInvalid != nullptr))
       destBuffers.push_back(SourceDestBuffer(imf_, "isColorInvalid", isColorInvalid, (unsigned)count, true));
-    else if (pointDataExtension != NULL)
+    else if (pointDataExtension != nullptr)
       (*pointDataExtension)(imf_, proto, (int)protoIndex, destBuffers);
   }
 
@@ -2284,7 +2284,7 @@ int32_t WriterImpl ::NewData3D(Data3D& data3DHeader,                            
   //   proto.set("demo:extra2", StringNode(imf_));	//Extension here
 
   // do call back to setup any point data extension before the CompressedVectorNode is created.
-  if (pointExtension != NULL)
+  if (pointExtension != nullptr)
     (*pointExtension)(imf_, proto);
 
   // Make empty codecs vector for use in creating points CompressedVector.
@@ -2350,22 +2350,22 @@ CompressedVectorWriter WriterImpl ::SetUpData3DPointsData(
   StructureNode        proto(points.prototype());
 
   vector<SourceDestBuffer> sourceBuffers;
-  if (proto.isDefined("cartesianX") && (cartesianX != NULL))
+  if (proto.isDefined("cartesianX") && (cartesianX != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "cartesianX", cartesianX, (unsigned)count, true, true));
-  if (proto.isDefined("cartesianY") && (cartesianY != NULL))
+  if (proto.isDefined("cartesianY") && (cartesianY != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "cartesianY", cartesianY, (unsigned)count, true, true));
 #ifdef TEST_EXTENSIONS
   if (proto.isDefined("ext:extraField1"))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "ext:extraField1", extraField1, (unsigned)count, true));
 #endif
-  if (proto.isDefined("cartesianZ") && (cartesianZ != NULL))
+  if (proto.isDefined("cartesianZ") && (cartesianZ != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "cartesianZ", cartesianZ, (unsigned)count, true, true));
 
-  if (proto.isDefined("sphericalRange") && (sphericalRange != NULL))
+  if (proto.isDefined("sphericalRange") && (sphericalRange != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "sphericalRange", sphericalRange, (unsigned)count, true, true));
-  if (proto.isDefined("sphericalAzimuth") && (sphericalAzimuth != NULL))
+  if (proto.isDefined("sphericalAzimuth") && (sphericalAzimuth != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "sphericalAzimuth", sphericalAzimuth, (unsigned)count, true, true));
-  if (proto.isDefined("sphericalElevation") && (sphericalElevation != NULL))
+  if (proto.isDefined("sphericalElevation") && (sphericalElevation != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "sphericalElevation", sphericalElevation, (unsigned)count, true, true));
 
 #ifdef TEST_EXTENSIONS
@@ -2373,45 +2373,45 @@ CompressedVectorWriter WriterImpl ::SetUpData3DPointsData(
     sourceBuffers.push_back(SourceDestBuffer(imf_, "ext:extraField2", extraField2, (unsigned)count, true));
 #endif
 
-  if (proto.isDefined("intensity") && (intensity != NULL))
+  if (proto.isDefined("intensity") && (intensity != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "intensity", intensity, (unsigned)count, true, true));
 
-  if (proto.isDefined("colorRed") && (colorRed != NULL))
+  if (proto.isDefined("colorRed") && (colorRed != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "colorRed", colorRed, (unsigned)count, true));
-  if (proto.isDefined("colorGreen") && (colorGreen != NULL))
+  if (proto.isDefined("colorGreen") && (colorGreen != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "colorGreen", colorGreen, (unsigned)count, true));
-  if (proto.isDefined("colorBlue") && (colorBlue != NULL))
+  if (proto.isDefined("colorBlue") && (colorBlue != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "colorBlue", colorBlue, (unsigned)count, true));
 
-  if (proto.isDefined("returnIndex") && (returnIndex != NULL))
+  if (proto.isDefined("returnIndex") && (returnIndex != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "returnIndex", returnIndex, (unsigned)count, true));
-  if (proto.isDefined("returnCount") && (returnCount != NULL))
+  if (proto.isDefined("returnCount") && (returnCount != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "returnCount", returnCount, (unsigned)count, true));
 
-  if (proto.isDefined("rowIndex") && (rowIndex != NULL))
+  if (proto.isDefined("rowIndex") && (rowIndex != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "rowIndex", rowIndex, (unsigned)count, true));
-  if (proto.isDefined("columnIndex") && (columnIndex != NULL))
+  if (proto.isDefined("columnIndex") && (columnIndex != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "columnIndex", columnIndex, (unsigned)count, true));
 
-  if (proto.isDefined("timeStamp") && (timeStamp != NULL))
+  if (proto.isDefined("timeStamp") && (timeStamp != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "timeStamp", timeStamp, (unsigned)count, true, true));
 
 #ifdef TEST_EXTENSIONS
   if (proto.isDefined("ext:extraField3"))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "ext:extraField3", extraField3, (unsigned)count, true));
 #endif
-  if (proto.isDefined("cartesianInvalidState") && (cartesianInvalidState != NULL))
+  if (proto.isDefined("cartesianInvalidState") && (cartesianInvalidState != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "cartesianInvalidState", cartesianInvalidState, (unsigned)count, true));
-  if (proto.isDefined("sphericalInvalidState") && (sphericalInvalidState != NULL))
+  if (proto.isDefined("sphericalInvalidState") && (sphericalInvalidState != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "sphericalInvalidState", sphericalInvalidState, (unsigned)count, true));
-  if (proto.isDefined("isIntensityInvalid") && (isIntensityInvalid != NULL))
+  if (proto.isDefined("isIntensityInvalid") && (isIntensityInvalid != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "isIntensityInvalid", isIntensityInvalid, (unsigned)count, true));
-  if (proto.isDefined("isColorInvalid") && (isColorInvalid != NULL))
+  if (proto.isDefined("isColorInvalid") && (isColorInvalid != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "isColorInvalid", isColorInvalid, (unsigned)count, true));
-  if (proto.isDefined("isTimeStampInvalid") && (isTimeStampInvalid != NULL))
+  if (proto.isDefined("isTimeStampInvalid") && (isTimeStampInvalid != nullptr))
     sourceBuffers.push_back(SourceDestBuffer(imf_, "isTimeStampInvalid", isTimeStampInvalid, (unsigned)count, true));
 
-  if (pointDataExtension != NULL)
+  if (pointDataExtension != nullptr)
     (*pointDataExtension)(imf_, proto, sourceBuffers);
 
   // create the writer, all buffers must be setup before this call

--- a/src/lib/src/time_conversion.cpp
+++ b/src/lib/src/time_conversion.cpp
@@ -6,7 +6,7 @@
 #define ERROR_MESSAGE(msg)                                                                                                                                     \
   {                                                                                                                                                            \
     const char* themsg = msg;                                                                                                                                  \
-    if (themsg != NULL)                                                                                                                                        \
+    if (themsg != nullptr)                                                                                                                                        \
     {                                                                                                                                                          \
       printf("\n%s,\n%s, %d,\n%s\n", __FILE__, __func__, __LINE__, themsg);                                                                                    \
     }                                                                                                                                                          \

--- a/src/lib/src/time_conversion.cpp
+++ b/src/lib/src/time_conversion.cpp
@@ -570,7 +570,7 @@ constexpr const int    DAYS_IN_DEC                   = 31;
   else
     utc_offset = 15;
   /*
-   * 12/Sep/2009 (KA): The following program will print out the required julian date for the next leap second (after editting year/month).
+   * 12/Sep/2009 (KA): The following program will print out the required julian date for the next leap second (after editing year/month).
    * #include <iostream>
    * #include <iomanip>
    * #include "time_conversion.h"

--- a/src/tools/e57validate.cpp
+++ b/src/tools/e57validate.cpp
@@ -1905,7 +1905,7 @@ void E57Validator::validatePointRecordContents(CompressedVectorNode cv, Structur
 
           /// Get lineIndex from row or column
           bool    usesLineGroups = lineGrouping.isDefined();
-          int64_t lineIndex;
+          int64_t lineIndex{0};
           if (usesLineGroups)
           {
             if (lineGrouping.isByRow())
@@ -2053,7 +2053,7 @@ void E57Validator::validatePointRecordContents(CompressedVectorNode cv, Structur
 
           /// Get lineIndex from row or column
           bool    usesLineGroups = lineGrouping.isDefined();
-          int64_t lineIndex;
+          int64_t lineIndex{0};
           if (usesLineGroups)
           {
             if (lineGrouping.isByRow())


### PR DESCRIPTION
[[modernize] use nullptr instead of NULL](https://github.com/openE57/openE57/commit/33ef69c8f62078e4b1d101a00339e437547b81ff)

[[doc] correction of numerous typos in the documentation](https://github.com/openE57/openE57/commit/db7a3d3e2f99b8bfe01cd91a637bf57f1312b217)

[initialize variable lineIndex with 0 to fix (MSVC) compiler warning](https://github.com/openE57/openE57/commit/00285e9ab3b235060d22ccd36534191198b62c78)

[fix a compiler warning (MSVC) using a constexpr instead of a cont](https://github.com/openE57/openE57/commit/d2464ef7ffdd3588af645923004d6cd191ed702b)